### PR TITLE
feat: 퀴즈 생성 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-json'
 	implementation 'org.json:json:20230227' // JSON 데이터를 다루기 위한 라이브러리 추가
 
-
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/QRAB/QRAB/chatgpt/service/ChatgptService.java
+++ b/src/main/java/QRAB/QRAB/chatgpt/service/ChatgptService.java
@@ -6,6 +6,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import QRAB.QRAB.quiz.domain.Quiz;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class ChatgptService {
@@ -32,5 +40,56 @@ public class ChatgptService {
 
         return chatgptResponseDTO != null ? chatgptResponseDTO.getFirstChoiceContent() : "";
     }
+    // 퀴즈 생성
+    public List<Quiz> generateQuiz(String quizPrompt) {
+        ChatgptRequestDTO chatgptRequestDTO = new ChatgptRequestDTO(model, quizPrompt);
+        ChatgptResponseDTO chatgptResponseDTO = restTemplate.postForObject(apiUrl, chatgptRequestDTO, ChatgptResponseDTO.class);
 
+        if (chatgptResponseDTO != null && chatgptResponseDTO.getFirstChoiceContent() != null) {
+            return parseQuizFromResponse(chatgptResponseDTO.getFirstChoiceContent());
+        }
+        return new ArrayList<>();
+    }
+
+    // GPT 응답을 Quiz 리스트로 변환
+    private List<Quiz> parseQuizFromResponse(String content) {
+        List<Quiz> quizzes = new ArrayList<>();
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            List<Map<String, Object>> quizMaps = mapper.readValue(content, new TypeReference<List<Map<String, Object>>>(){});
+
+            for (Map<String, Object> quizMap : quizMaps) {
+                Quiz quiz = new Quiz();
+                quiz.setDifficulty((String) quizMap.get("difficulty"));
+                quiz.setQuestion((String) quizMap.get("question"));
+
+                // choices 필드를 문자열 리스트로 변환
+                List<String> choices = ((List<?>) quizMap.get("choices")).stream()
+                        .map(Object::toString)
+                        .collect(Collectors.toList());
+                quiz.setChoicesAsList(choices);
+
+                // correct_answer 필드 처리
+                // Integer 또는 String일 가능성을 모두 고려하여 처리
+                Object correctAnswerObj = quizMap.get("correct_answer");
+                int correctAnswer;
+                if (correctAnswerObj instanceof Integer) {
+                    correctAnswer = (Integer) correctAnswerObj;
+                } else if (correctAnswerObj instanceof String) {
+                    correctAnswer = Integer.parseInt((String) correctAnswerObj);
+                } else {
+                    throw new IllegalArgumentException("Invalid correct_answer format: " + correctAnswerObj);
+                }
+                quiz.setCorrectAnswer(correctAnswer);
+
+                quiz.setExplanation((String) quizMap.get("explanation"));
+                quiz.setQuizSummary((String) quizMap.get("quiz_summary"));
+
+                quizzes.add(quiz);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return quizzes;
+    }
 }

--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
@@ -1,0 +1,36 @@
+package QRAB.QRAB.quiz.controller;
+
+import QRAB.QRAB.quiz.dto.QuizSetDTO;
+import QRAB.QRAB.quiz.dto.QuizGenerationRequestDTO;
+import QRAB.QRAB.quiz.domain.Quiz;
+import QRAB.QRAB.quiz.service.QuizService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/quiz-lab")
+public class QuizController {
+    private final QuizService quizService;
+
+    @Autowired
+    public QuizController(QuizService quizService){
+        this.quizService = quizService;
+    }
+
+    // 퀴즈 세트 생성 엔드포인트
+    @PostMapping("/generate")
+    public ResponseEntity<QuizSetDTO> generateQuizSet(@RequestBody QuizGenerationRequestDTO requestDTO){
+        QuizSetDTO quizSetDTO = quizService.createQuizSet(requestDTO);
+        return ResponseEntity.ok(quizSetDTO);
+    }
+
+    // 특정 퀴즈 세트의 퀴즈 조회 엔드포인트
+    @GetMapping("/{quizSetId}/quizzes")
+    public ResponseEntity<List<Quiz>> getQuizzesByQuizSetId(@PathVariable Long quizSetId){
+        List<Quiz> quizzes = quizService.getQuizzesByQuizSetId(quizSetId);
+        return ResponseEntity.ok(quizzes);
+    }
+
+}

--- a/src/main/java/QRAB/QRAB/quiz/domain/Quiz.java
+++ b/src/main/java/QRAB/QRAB/quiz/domain/Quiz.java
@@ -1,0 +1,109 @@
+package QRAB.QRAB.quiz.domain;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+@Entity
+public class Quiz {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long quizId;
+
+    private String difficulty;
+    private String question;
+    private String choices; // JSON 문자열로 저장
+    private int correctAnswer;
+    private String explanation;
+    private String quizSummary;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_set_id")
+    private QuizSet quizSet;
+
+    public Long getQuizId() {
+        return quizId;
+    }
+
+    public void setQuizId(Long quizId) {
+        this.quizId = quizId;
+    }
+
+    public String getDifficulty() {
+        return difficulty;
+    }
+
+    public void setDifficulty(String difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(String question) {
+        this.question = question;
+    }
+
+    public String getChoices() {
+        return choices;
+    }
+
+    public void setChoices(String choices) {
+        this.choices = choices;
+    }
+
+    // Choices를 리스트로 변환
+    public List<String> getChoicesAsList() {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(choices, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse choices to List", e);
+        }
+    }
+
+    // Choices를 JSON 문자열로 설정
+    public void setChoicesAsList(List<String> choicesList) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            this.choices = mapper.writeValueAsString(choicesList);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert choices List to JSON", e);
+        }
+    }
+
+    public int getCorrectAnswer() {
+        return correctAnswer;
+    }
+
+    public void setCorrectAnswer(int correctAnswer) {
+        this.correctAnswer = correctAnswer;
+    }
+
+    public String getExplanation() {
+        return explanation;
+    }
+
+    public void setExplanation(String explanation) {
+        this.explanation = explanation;
+    }
+
+    public String getQuizSummary() {
+        return quizSummary;
+    }
+
+    public void setQuizSummary(String quizSummary) {
+        this.quizSummary = quizSummary;
+    }
+
+    public QuizSet getQuizSet() {
+        return quizSet;
+    }
+
+    public void setQuizSet(QuizSet quizSet) {
+        this.quizSet = quizSet;
+    }
+}

--- a/src/main/java/QRAB/QRAB/quiz/domain/QuizSet.java
+++ b/src/main/java/QRAB/QRAB/quiz/domain/QuizSet.java
@@ -1,0 +1,98 @@
+package QRAB.QRAB.quiz.domain;
+
+import QRAB.QRAB.note.domain.Note;
+import QRAB.QRAB.user.domain.User;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+public class QuizSet {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long quizSetId;
+
+    private int totalQuestions;
+    private LocalDateTime createdAt;
+    private String status;
+    private float accuracyRate = 0.0f; // 초기 정답률
+
+    @OneToMany(mappedBy = "quizSet", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Quiz> quizzes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "note_id", referencedColumnName = "note_id") // Note와의 관계 설정
+    private Note note;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id") // User와의 관계 설정
+    private User user;
+
+    public QuizSet() {
+        // 기본 생성자
+    }
+
+    public Long getQuizSetId() {
+        return quizSetId;
+    }
+
+    public void setQuizSetId(Long quizSetId) {
+        this.quizSetId = quizSetId;
+    }
+
+    public Note getNote() {
+        return note;
+    }
+
+    public void setNote(Note note) {
+        this.note = note;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public int getTotalQuestions() {
+        return totalQuestions;
+    }
+
+    public void setTotalQuestions(int totalQuestions) {
+        this.totalQuestions = totalQuestions;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public float getAccuracyRate() {
+        return accuracyRate;
+    }
+
+    public void setAccuracyRate(float accuracyRate) {
+        this.accuracyRate = accuracyRate;
+    }
+
+    public List<Quiz> getQuizzes() {
+        return quizzes;
+    }
+
+    public void setQuizzes(List<Quiz> quizzes) {
+        this.quizzes = quizzes;
+    }
+}

--- a/src/main/java/QRAB/QRAB/quiz/dto/QuizGenerationRequestDTO.java
+++ b/src/main/java/QRAB/QRAB/quiz/dto/QuizGenerationRequestDTO.java
@@ -1,0 +1,27 @@
+package QRAB.QRAB.quiz.dto;
+
+public class QuizGenerationRequestDTO {
+    private Long userId;
+    private Long noteId;
+    private int totalQuestions;
+
+    public Long getUserId() { return userId; }
+
+    public void setUserId(Long userId) { this.userId = userId; }
+
+    public Long getNoteId() {
+        return noteId;
+    }
+
+    public void setNoteId(Long noteId) {
+        this.noteId = noteId;
+    }
+
+    public int getTotalQuestions() {
+        return totalQuestions;
+    }
+
+    public void setTotalQuestions(int totalQuestions) {
+        this.totalQuestions = totalQuestions;
+    }
+}

--- a/src/main/java/QRAB/QRAB/quiz/dto/QuizSetDTO.java
+++ b/src/main/java/QRAB/QRAB/quiz/dto/QuizSetDTO.java
@@ -1,0 +1,77 @@
+package QRAB.QRAB.quiz.dto;
+
+import QRAB.QRAB.quiz.domain.QuizSet;
+
+import java.time.LocalDateTime;
+
+public class QuizSetDTO {
+    private Long quizSetId;
+    private Long noteId;
+    private Long userId;
+    private int totalQuestions;
+    private LocalDateTime createdAt;
+    private String status;
+    private float accuracyRate;
+
+    public QuizSetDTO(QuizSet quizSet){
+        this.quizSetId = quizSet.getQuizSetId();
+        this.noteId = quizSet.getNote() != null ? quizSet.getNote().getId() : null;
+        this.userId = quizSet.getUser() != null ? quizSet.getUser().getUserId() : null; // User 객체에서 ID 가져오기
+        this.totalQuestions = quizSet.getTotalQuestions();
+        this.createdAt = quizSet.getCreatedAt();
+        this.status = quizSet.getStatus();
+        this.accuracyRate = quizSet.getAccuracyRate();
+    }
+
+    public Long getQuizSetId() {
+        return quizSetId;
+    }
+
+    public void setQuizSetId(Long quizSetId) {
+        this.quizSetId = quizSetId;
+    }
+
+    public Long getNoteId() {
+        return noteId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setNoteId(Long noteId) {
+        this.noteId = noteId;
+    }
+
+    public int getTotalQuestions() {
+        return totalQuestions;
+    }
+
+    public void setTotalQuestions(int totalQuestions) {
+        this.totalQuestions = totalQuestions;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public float getAccuracyRate() {
+        return accuracyRate;
+    }
+
+    public void setAccuracyRate(float accuracyRate) {
+        this.accuracyRate = accuracyRate;
+    }
+}

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizRepository.java
@@ -1,0 +1,12 @@
+package QRAB.QRAB.quiz.repository;
+
+import QRAB.QRAB.quiz.domain.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+    List<Quiz> findByQuizSet_QuizSetId(Long quizSetId);
+}

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizSetRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizSetRepository.java
@@ -1,0 +1,9 @@
+package QRAB.QRAB.quiz.repository;
+
+import QRAB.QRAB.quiz.domain.QuizSet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizSetRepository extends JpaRepository<QuizSet, Long> {
+}

--- a/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
+++ b/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
@@ -1,0 +1,138 @@
+package QRAB.QRAB.quiz.service;
+
+import QRAB.QRAB.quiz.dto.QuizGenerationRequestDTO;
+import QRAB.QRAB.quiz.dto.QuizSetDTO;
+import QRAB.QRAB.quiz.domain.Quiz;
+import QRAB.QRAB.quiz.domain.QuizSet;
+import QRAB.QRAB.chatgpt.service.ChatgptService;
+import QRAB.QRAB.quiz.repository.QuizRepository;
+import QRAB.QRAB.quiz.repository.QuizSetRepository;
+import QRAB.QRAB.note.domain.Note;
+import QRAB.QRAB.note.repository.NoteRepository;
+import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.user.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class QuizService {
+    private final QuizRepository quizRepository;
+    private final QuizSetRepository quizSetRepository;
+    private final ChatgptService chatgptService;
+    private final UserService userService;
+    private final NoteRepository noteRepository;
+
+    @Autowired
+    public QuizService(QuizRepository quizRepository, QuizSetRepository quizSetRepository, ChatgptService chatgptService, UserService userService, NoteRepository noteRepository) {
+        this.quizRepository = quizRepository;
+        this.quizSetRepository = quizSetRepository;
+        this.chatgptService = chatgptService;
+        this.userService = userService;
+        this.noteRepository = noteRepository;
+    }
+
+    public QuizSetDTO createQuizSet(QuizGenerationRequestDTO requestDTO) {
+        // 1. 사용자와 노트 객체 가져오기
+        User user = userService.getUserById(requestDTO.getUserId());
+        Note note = noteRepository.findById(requestDTO.getNoteId())
+                .orElseThrow(() -> new RuntimeException("노트를 찾을 수 없습니다."));
+
+        // 2. 퀴즈 세트 생성 및 저장
+        QuizSet quizSet = new QuizSet();
+        quizSet.setUser(user);
+        quizSet.setNote(note);
+        quizSet.setTotalQuestions(requestDTO.getTotalQuestions());
+        quizSet.setStatus("unsolved");
+        quizSet.setCreatedAt(LocalDateTime.now());
+        quizSetRepository.save(quizSet);
+
+        // 3. 사용자 전공 정보 가져오기
+        Set<String> majorNames = user.getMajors().stream()
+                .map(major -> major.getName())
+                .collect(Collectors.toSet());
+
+        String majorInfo = "주전공: " + majorNames.iterator().next(); // 첫 번째 전공을 주전공으로 가정
+        List<String> additionalMajors = majorNames.stream().skip(1).collect(Collectors.toList());
+        if (!additionalMajors.isEmpty()) {
+            majorInfo += ", 복수전공1: " + additionalMajors.get(0);
+        }
+        if (additionalMajors.size() > 1) {
+            majorInfo += ", 복수전공2: " + additionalMajors.get(1);
+        }
+
+        // 4. 노트 요약 내용 가져오기
+        String noteSummary = note.getChatgptContent(); // 요약본을 가져옴
+
+        // 5. 퀴즈 생성 프롬프트 작성
+        String quizPrompt = String.format(
+                "다음은 사용자가 풀어야 할 퀴즈를 생성하는 요청입니다. 퀴즈는 객관식 사지선다형이며, 각 퀴즈에 대해 난이도, 질문, 선택지, 정답, 풀이, 퀴즈 요약을 포함해 주세요. 총 %d개의 퀴즈를 생성해 주세요.\n\n" +
+                        "사용자의 전공 정보는 다음과 같습니다:\n" +
+                        "- %s\n\n" +
+                        "난이도를 책정하는 기준은 다음과 같습니다:\n" +
+                        "- easy: 주제에 대한 기본 개념을 묻고 있음. 10명 중 8명 이상의 정답자가 예상됨.\n" +
+                        "- medium: 주제에 대한 심화 개념이나 더 깊은 이해를 요구함. 10명 중 5명 이하의 정답자가 예상됨.\n" +
+                        "- hard: 주제에 대해 medium 난이도보다 더 깊은 이해를 요구함. 10명 중 3명 이하의 정답자가 예상됨.\n\n" +
+                        "블로그 내용은 사용자의 전공과 관련될 수 있습니다. 이 정보를 바탕으로 퀴즈를 생성해 주세요.\n\n" +
+                        "각 퀴즈의 형식은 JSON 형식으로 다음과 같이 작성해 주세요:\n" +
+                        "{\n" +
+                        "  \"difficulty\": \"난이도 (easy, medium, hard 중 하나)\",\n" +
+                        "  \"question\": \"퀴즈 질문 내용\",\n" +
+                        "  \"choices\": [\n" +
+                        "    \"a. 선택지 1\",\n" +
+                        "    \"b. 선택지 2\",\n" +
+                        "    \"c. 선택지 3\",\n" +
+                        "    \"d. 선택지 4\"\n" +
+                        "  ],\n" +
+                        "  \"correct_answer\": \"정답의 선택지 번호 (0부터 시작하여 0, 1, 2, 3 중 하나)\",\n" +
+                        "  \"explanation\": \"정답 풀이\",\n" +
+                        "  \"quiz_summary\": \"퀴즈 요약\"\n" +
+                        "}\n" +
+                        "정답의 선택지 번호는 0, 1, 2, 3이 고루 분포되어야 합니다.\n\n" +
+                        "다음은 실제 사용자가 입력한 블로그 내용입니다. 반드시 이 블로그 내용에 관한 퀴즈를 %d개 출제하고, JSON 형식의 앞뒤에 아무 말도 덧붙이지 말고 JSON 형식으로만 반환해 주세요.:\n\n%s",
+                requestDTO.getTotalQuestions(),
+                majorInfo,
+                requestDTO.getTotalQuestions(),
+                noteSummary
+        );
+
+        // 6. GPT API 호출하여 퀴즈 생성
+        List<Quiz> quizzes = chatgptService.generateQuiz(quizPrompt);
+
+        // 7. 생성된 퀴즈를 데이터베이스에 저장
+        for (Quiz quiz : quizzes) {
+            quiz.setQuizSet(quizSet);
+            quiz.setChoicesAsList(quiz.getChoicesAsList()); // JSON 문자열로 변환 후 저장
+            quizRepository.save(quiz);
+        }
+
+        // 8. QuizSet DTO 생성하여 반환
+        return new QuizSetDTO(quizSet);
+    }
+
+    /*
+    // 퀴즈 파싱 및 저장 로직
+    private List<Quiz> parseAndSaveQuizzes(String gptResponse, Long quizSetId) {
+        List<Quiz> quizzes = new ArrayList<>();
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            quizzes = mapper.readValue(gptResponse, new TypeReference<List<Quiz>>(){});
+            for(Quiz quiz : quizzes){
+                quiz.setQuizSet(quizSetRepository.findById(quizSetId).orElseThrow(() -> new RuntimeException("퀴즈 세트가 존재하지 않습니다.")));
+                quizRepository.save(quiz);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return quizzes;
+    }
+     */
+
+    public List<Quiz> getQuizzesByQuizSetId(Long quizSetId){
+        return quizRepository.findByQuizSet_QuizSetId(quizSetId);
+    }
+}

--- a/src/main/java/QRAB/QRAB/user/service/UserService.java
+++ b/src/main/java/QRAB/QRAB/user/service/UserService.java
@@ -37,6 +37,12 @@ public class UserService {
     public boolean checkNicknameDuplicate(String nickname) {
         return userRepository.findByNickname(nickname).isPresent();
     }
+    @Transactional(readOnly = true)
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다. ID: " + userId));
+    }
+
 
     @Transactional
     public UserDTO signup(UserDTO userDto) {


### PR DESCRIPTION
- QuizService를 통해 OpenAI API를 호출하여 난이도, 선택지, 정답, 설명 등이 포함된 퀴즈를 생성하고 저장하게 했습니다.
- 퀴즈 세트 생성 및 저장 후 사용자 전공 정보와 노트 요약 내용을 기반으로 퀴즈를 생성해 퀴즈 세트에 추가하도록 했습니다.
- QuizSet 엔티티와 User, Note를 매핑했습니다.