### PR TITLE
feat: 퀴즈 연구소 저장된 노트 조회 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/note/domain/Note.java
+++ b/src/main/java/QRAB/QRAB/note/domain/Note.java
@@ -28,6 +28,8 @@ public class Note extends BaseTimeEntity {
     private String file;//파일 경로 - pdf, 사진
     private boolean restrictedAccess; //기본값 false : 공개
 
+    private int quizGenerationCount = 0; // 퀴즈 생성 횟수 (기본값 0)
+
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name="user_id")
     private User user;
 
@@ -35,7 +37,7 @@ public class Note extends BaseTimeEntity {
     private Category category;
 
     @Builder
-    public Note(String title, String content, String chatgptContent, String url, String file, boolean restrictedAccess, User user, Category category){
+    public Note(String title, String content, String chatgptContent, String url, String file, boolean restrictedAccess, User user, Category category, int quizGenerationCount){
         this.title = title;
         this.content = content;
         this.chatgptContent = chatgptContent;
@@ -44,5 +46,6 @@ public class Note extends BaseTimeEntity {
         this.restrictedAccess =restrictedAccess;
         this.user = user;
         this.category = category;
+        this.quizGenerationCount = quizGenerationCount;
     }
 }

--- a/src/main/java/QRAB/QRAB/note/dto/QuizLabNoteResponseDTO.java
+++ b/src/main/java/QRAB/QRAB/note/dto/QuizLabNoteResponseDTO.java
@@ -1,0 +1,30 @@
+package QRAB.QRAB.note.dto;
+
+import QRAB.QRAB.note.domain.Note;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuizLabNoteResponseDTO {
+    private Long noteId;
+    private String title;
+    private String chatgptContent;
+    private String categoryName;
+    private String parentCategoryName;
+    private String fileOrUrl;
+    private int quizGenerationCount; // 퀴즈 생성 횟수 추가
+
+    public static QuizLabNoteResponseDTO fromEntity(Note note) {
+        return new QuizLabNoteResponseDTO(
+                note.getId(),
+                note.getTitle(),
+                note.getChatgptContent().length() > 100 ? note.getChatgptContent().substring(0, 100) : note.getChatgptContent(),
+                note.getCategory().getName(),
+                note.getCategory().getParentCategory() != null ? note.getCategory().getParentCategory().getName() : "",
+                note.getUrl() != null ? note.getUrl() : note.getFile(),
+                note.getQuizGenerationCount() // 퀴즈 생성 횟수 가져오기
+        );
+    }
+}
+

--- a/src/main/java/QRAB/QRAB/note/service/NoteService.java
+++ b/src/main/java/QRAB/QRAB/note/service/NoteService.java
@@ -4,6 +4,7 @@ import QRAB.QRAB.category.domain.Category;
 import QRAB.QRAB.category.repository.CategoryRepository;
 import QRAB.QRAB.note.domain.Note;
 import QRAB.QRAB.note.dto.NoteResponseDTO;
+import QRAB.QRAB.note.dto.QuizLabNoteResponseDTO;
 import QRAB.QRAB.note.dto.RecentNoteDTO;
 import QRAB.QRAB.note.dto.SummaryResponseDTO;
 import QRAB.QRAB.note.repository.NoteRepository;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,4 +80,21 @@ public class NoteService {
                 .collect(Collectors.toList());
         return recentNoteDTOS;
     }
+
+    // 추가: 퀴즈 연구소에서 사용될 저장된 노트 조회 메소드
+
+    @Transactional(readOnly = true)
+    public List<QuizLabNoteResponseDTO> getStoredNotesForQuizLab(int page) {
+        // SecurityContext에서 현재 인증된 사용자 정보 가져오기
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("Could not find user with email"));
+        Pageable pageable = PageRequest.of(page, 6, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Note> notes = noteRepository.findByUser(user, pageable);
+
+        return notes.getContent().stream()
+                .map(QuizLabNoteResponseDTO::fromEntity)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
@@ -1,11 +1,14 @@
 package QRAB.QRAB.quiz.controller;
 
+import QRAB.QRAB.note.dto.QuizLabNoteResponseDTO;
+import QRAB.QRAB.note.service.NoteService;
 import QRAB.QRAB.quiz.dto.QuizSetDTO;
 import QRAB.QRAB.quiz.dto.QuizGenerationRequestDTO;
 import QRAB.QRAB.quiz.domain.Quiz;
 import QRAB.QRAB.quiz.service.QuizService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -13,10 +16,12 @@ import java.util.List;
 @RequestMapping("/quiz-lab")
 public class QuizController {
     private final QuizService quizService;
+    private final NoteService noteService;
 
     @Autowired
-    public QuizController(QuizService quizService){
+    public QuizController(QuizService quizService, NoteService noteService){
         this.quizService = quizService;
+        this.noteService = noteService;
     }
 
     // 퀴즈 세트 생성 엔드포인트
@@ -33,4 +38,15 @@ public class QuizController {
         return ResponseEntity.ok(quizzes);
     }
 
+    // 저장된 노트 리스트 조회 엔드포인트 (퀴즈 연구소 화면용)
+    @GetMapping("/notes")
+    public ResponseEntity<List<QuizLabNoteResponseDTO>> getStoredNotesForQuizLab(
+            @RequestParam(name = "page", defaultValue = "0") int page) {
+        // SecurityContextHolder를 사용하여 인증된 사용자 정보 가져오기
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        // 인증된 사용자의 노트 목록 조회
+        List<QuizLabNoteResponseDTO> storedNotes = noteService.getStoredNotesForQuizLab(page);
+        return ResponseEntity.ok(storedNotes);
+    }
 }

--- a/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
+++ b/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
@@ -41,6 +41,9 @@ public class QuizService {
         User user = userService.getUserById(requestDTO.getUserId());
         Note note = noteRepository.findById(requestDTO.getNoteId())
                 .orElseThrow(() -> new RuntimeException("노트를 찾을 수 없습니다."));
+        // 퀴즈 생성 시 노트의 퀴즈 생성 횟수 증가
+        note.setQuizGenerationCount(note.getQuizGenerationCount() + 1);
+        noteRepository.save(note);
 
         // 2. 퀴즈 세트 생성 및 저장
         QuizSet quizSet = new QuizSet();


### PR DESCRIPTION
- 퀴즈 연구소 화면에서 저장된 노트 조회 시 해당 노트로 생성된 퀴즈 횟수를 알 수 있도록 quizGenerationCount 필드를 추가했습니다.
- 노트를 6개씩 페이지네이션할 수 있도록 기능을 구현했습니다.