### PR TITLE
feat: 퀴즈 풀기 조회 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizSolvingController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizSolvingController.java
@@ -1,0 +1,30 @@
+package QRAB.QRAB.quiz.controller;
+
+import QRAB.QRAB.quiz.dto.UnsolvedQuizSetResponseDTO;
+import QRAB.QRAB.quiz.service.QuizService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/quiz-solving")
+public class QuizSolvingController {
+
+    private final QuizService quizService;
+
+    @Autowired
+    public QuizSolvingController(QuizService quizService) {
+        this.quizService = quizService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<UnsolvedQuizSetResponseDTO>> findUnsolvedQuizSets(
+            @RequestParam(name = "page", defaultValue = "0") int page) {
+        Page<UnsolvedQuizSetResponseDTO> unsolvedQuizSets = quizService.findUnsolvedQuizSets(page);
+        return ResponseEntity.ok(unsolvedQuizSets);
+    }
+}

--- a/src/main/java/QRAB/QRAB/quiz/dto/UnsolvedQuizSetResponseDTO.java
+++ b/src/main/java/QRAB/QRAB/quiz/dto/UnsolvedQuizSetResponseDTO.java
@@ -1,0 +1,30 @@
+package QRAB.QRAB.quiz.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UnsolvedQuizSetResponseDTO {
+
+    private Long quizSetId;
+    private Long noteId;
+    private String noteTitle;
+    private LocalDateTime createdAt;
+    private String solvedAt;
+    private String status;
+
+    public UnsolvedQuizSetResponseDTO(Long quizSetId, Long noteId, String noteTitle,
+                                      LocalDateTime createdAt, String solvedAt, String status) {
+        this.quizSetId = quizSetId;
+        this.noteId = noteId;
+        this.noteTitle = noteTitle;
+        this.createdAt = createdAt;
+        this.solvedAt = solvedAt;
+        this.status = status;
+    }
+
+}
+

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizSetRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizSetRepository.java
@@ -1,9 +1,14 @@
 package QRAB.QRAB.quiz.repository;
 
 import QRAB.QRAB.quiz.domain.QuizSet;
+import QRAB.QRAB.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QuizSetRepository extends JpaRepository<QuizSet, Long> {
+    // status가 'unsolved'인 퀴즈세트만 조회
+    Page<QuizSet> findByUserAndStatus(User user, String status, Pageable pageable);
 }

--- a/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
+++ b/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
@@ -7,6 +7,7 @@ import QRAB.QRAB.quiz.dto.QuizSetDTO;
 import QRAB.QRAB.quiz.domain.Quiz;
 import QRAB.QRAB.quiz.domain.QuizSet;
 import QRAB.QRAB.chatgpt.service.ChatgptService;
+import QRAB.QRAB.quiz.dto.UnsolvedQuizSetResponseDTO;
 import QRAB.QRAB.quiz.repository.QuizRepository;
 import QRAB.QRAB.quiz.repository.QuizResultRepository;
 import QRAB.QRAB.quiz.repository.QuizSetRepository;
@@ -143,6 +144,27 @@ public class QuizService {
         Page<QuizResult> quizResults = quizResultRepository.findAllSolvedQuizSets(pageable);
 
         return quizResults.map(this::convertToDto);
+    }
+
+    //퀴즈 풀기 페이지 조회(unsolved quizset 조회)
+    public Page<UnsolvedQuizSetResponseDTO> findUnsolvedQuizSets(int page) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("Could not find user with email: " + username));
+
+        // 한 페이지에 6개씩 페이징
+        Pageable pageable = PageRequest.of(page, 6);
+        Page<QuizSet> quizSets = quizSetRepository.findByUserAndStatus(user, "unsolved", pageable);
+
+        // 조회 결과 DTO로 변환하여 반환
+        return quizSets.map(quizSet -> new UnsolvedQuizSetResponseDTO(
+                quizSet.getQuizSetId(),
+                quizSet.getNote().getId(),
+                quizSet.getNote().getTitle(),
+                quizSet.getCreatedAt(),
+                "미풀이", // 아직 안 풀었으므로 풀이 일자 X
+                quizSet.getStatus()
+        ));
     }
 
     private QuizResultDTO convertToDto(QuizResult quizResult) {


### PR DESCRIPTION
- 퀴즈 풀기 페이지에는 미풀이 퀴즈만 있어야 하므로 status가 'unsolved'인 quizset을 조회
- 페이지네이션을 통해 한 페이지에 6개씩 반환하도록 구현