### PR TITLE
feat: 특정 노트 solved 퀴즈 세트 조회 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/note/controller/NoteController.java
+++ b/src/main/java/QRAB/QRAB/note/controller/NoteController.java
@@ -99,23 +99,18 @@ public class NoteController {
 
     }
 
-
-    @GetMapping("/{categoryId}")
-    public ResponseEntity<?> getNotePageByCategory(@PathVariable("categoryId") Long categoryId, @RequestParam(name = "page", defaultValue = "0") int page) {
+    private ResponseEntity<?> getNotesByCategoryResponse(Long categoryId, int page) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String username = authentication.getName();
 
-        // 사용자가 생성한 상위 카테고리 조회
+        // 상위 카테고리 조회
         List<CategoryParentResponseDTO> parentCategories = categoryService.getUserParentCategories(username);
 
         // 하위 카테고리 조회
         List<CategoryChildResponseDTO> childCategories = categoryService.getUserChildCategories(username);
 
-        List<NoteResponseDTO> sixNotesInfo;
-
         // 카테고리 ID가 제공된 경우 해당 카테고리의 노트 조회, 그렇지 않으면 최신 노트 조회
-        sixNotesInfo = noteService.getNotesByCategory(username, categoryId, page);
-
+        List<NoteResponseDTO> sixNotesInfo = noteService.getNotesByCategory(username, categoryId, page);
 
         // 최근 노트 3개 조회
         List<RecentNoteDTO> threeNoteInfo = noteService.getUserRecentNotesBy3(username);
@@ -129,5 +124,10 @@ public class NoteController {
         return ResponseEntity.ok(result);
     }
 
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<?> getNotePageByCategory(@PathVariable("categoryId") Long categoryId,
+                                                   @RequestParam(name = "page", defaultValue = "0") int page) {
+        return getNotesByCategoryResponse(categoryId, page);
+    }
 
 }

--- a/src/main/java/QRAB/QRAB/note/domain/Note.java
+++ b/src/main/java/QRAB/QRAB/note/domain/Note.java
@@ -2,9 +2,12 @@ package QRAB.QRAB.note.domain;
 
 import QRAB.QRAB.BaseTimeEntity;
 import QRAB.QRAB.category.domain.Category;
+import QRAB.QRAB.quiz.domain.QuizSet;
 import QRAB.QRAB.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -35,6 +38,9 @@ public class Note extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "category_id")
     private Category category;
+
+    @OneToMany(mappedBy = "note", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<QuizSet> quizSets;
 
     @Builder
     public Note(String title, String content, String chatgptContent, String url, String file, int restrictedAccess, User user, Category category, int quizGenerationCount){

--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
@@ -1,5 +1,6 @@
 package QRAB.QRAB.quiz.controller;
 
+import QRAB.QRAB.note.controller.NoteController;
 import QRAB.QRAB.note.dto.QuizLabNoteResponseDTO;
 import QRAB.QRAB.note.service.NoteService;
 import QRAB.QRAB.quiz.dto.QuizGradingResponseDTO;
@@ -20,11 +21,13 @@ import java.util.List;
 public class QuizController {
     private final QuizService quizService;
     private final NoteService noteService;
+    private final NoteController noteController;
 
     @Autowired
-    public QuizController(QuizService quizService, NoteService noteService){
+    public QuizController(QuizService quizService, NoteService noteService, NoteController noteController){
         this.quizService = quizService;
         this.noteService = noteService;
+        this.noteController = noteController;
     }
 
     // 퀴즈 세트 생성 엔드포인트
@@ -32,13 +35,6 @@ public class QuizController {
     public ResponseEntity<QuizSetDTO> generateQuizSet(@RequestBody QuizGenerationRequestDTO requestDTO){
         QuizSetDTO quizSetDTO = quizService.createQuizSet(requestDTO);
         return ResponseEntity.ok(quizSetDTO);
-    }
-
-    // 특정 퀴즈 세트의 채점 결과 조회 엔드포인트
-    @GetMapping("/quizzes/{quizSetId}")
-    public ResponseEntity<QuizGradingResponseDTO> getQuizSetResult(@PathVariable Long quizSetId) {
-        QuizGradingResponseDTO result = quizService.getQuizSetResult(quizSetId);
-        return ResponseEntity.ok(result);
     }
 
     // 저장된 노트 리스트 조회 엔드포인트 (퀴즈 연구소 화면용)
@@ -53,12 +49,33 @@ public class QuizController {
         return ResponseEntity.ok(storedNotes);
     }
 
+    @GetMapping("/quizzes/{categoryId}")
+    public ResponseEntity<?> getNotePageByCategoryInQuizLab(@PathVariable("categoryId") Long categoryId,
+                                                            @RequestParam(name = "page", defaultValue = "0") int page) {
+        return noteController.getNotePageByCategory(categoryId, page);
+    }
+
+    @GetMapping("/quizzes/{noteId}/solved")
+    public ResponseEntity<Page<QuizResultDTO>> getSolvedQuizSetsByNoteId(
+            @PathVariable("noteId") Long noteId,
+            @RequestParam(name = "page", defaultValue = "0") int page) {
+        Page<QuizResultDTO> solvedQuizSets = quizService.getSolvedQuizSetsByNoteId(noteId, page);
+        return ResponseEntity.ok(solvedQuizSets);
+    }
+
     // status가 solved인 퀴즈 세트 조회 엔드포인트 (퀴즈 저장소 화면용)
-    @GetMapping("/quizzes")
+    @GetMapping("/quizzes/solved")
     public ResponseEntity<Page<QuizResultDTO>> getSolvedQuizSets(
             @RequestParam(name = "page", defaultValue = "0") int page) {
         Page<QuizResultDTO> solvedQuizSets = quizService.getSolvedQuizSets(page);
         return ResponseEntity.ok(solvedQuizSets);
+    }
+
+    // 특정 퀴즈 세트의 채점 결과 조회 엔드포인트
+    @GetMapping("/quizzes/solved/{quizSetId}")
+    public ResponseEntity<QuizGradingResponseDTO> getQuizSetResult(@PathVariable Long quizSetId) {
+        QuizGradingResponseDTO result = quizService.getQuizSetResult(quizSetId);
+        return ResponseEntity.ok(result);
     }
 
 

--- a/src/main/java/QRAB/QRAB/quiz/dto/QuizResultDTO.java
+++ b/src/main/java/QRAB/QRAB/quiz/dto/QuizResultDTO.java
@@ -1,10 +1,18 @@
 package QRAB.QRAB.quiz.dto;
 
+import QRAB.QRAB.quiz.domain.QuizResult;
+import QRAB.QRAB.quiz.domain.QuizSet;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class QuizResultDTO {
+    private Long quizSetId;
     private String noteTitle;
     private int totalQuestions;
-    private String createdDate;
-    private String solvedDate;
+    private String createdAt;
+    private String solvedAt;
     private String answerSummary;
     private String categoryName;
     private String parentCategoryName;
@@ -12,66 +20,33 @@ public class QuizResultDTO {
     public QuizResultDTO(String noteTitle, int totalQuestions, String createdDate, String solvedDate, String answerSummary, String categoryName, String parentCategoryName) {
         this.noteTitle = noteTitle;
         this.totalQuestions = totalQuestions;
-        this.createdDate = createdDate;
-        this.solvedDate = solvedDate;
+        this.createdAt = createdAt;
+        this.solvedAt = solvedAt;
         this.answerSummary = answerSummary;
         this.categoryName = categoryName;
         this.parentCategoryName = parentCategoryName;
     }
 
-    public String getNoteTitle() {
-        return noteTitle;
+    public QuizResultDTO(QuizSet quizSet, QuizResult quizResult) {
+        this.quizSetId = quizSet.getQuizSetId();
+        this.noteTitle = quizSet.getNote().getTitle();
+        this.totalQuestions = quizSet.getTotalQuestions();
+        this.createdAt = quizSet.getCreatedAt().toString();
+        this.solvedAt = quizResult.getTakenAt() != null ? quizResult.getTakenAt().toString() : null;
+        this.answerSummary = generateAnswerSummary(quizResult); // 정답/오답 요약 생성
+        this.categoryName = quizSet.getNote().getCategory().getName();
+        this.parentCategoryName = quizSet.getNote().getCategory().getParentCategory() != null
+                ? quizSet.getNote().getCategory().getParentCategory().getName()
+                : "";
     }
 
-    public void setNoteTitle(String noteTitle) {
-        this.noteTitle = noteTitle;
-    }
+    private String generateAnswerSummary(QuizResult quizResult) {
+        int correctCount = quizResult.getCorrectCount();
+        int totalQuestions = quizResult.getTotalQuestions();
+        int wrongCount = totalQuestions - correctCount;
 
-    public int getTotalQuestions() {
-        return totalQuestions;
-    }
-
-    public void setTotalQuestions(int totalQuestions) {
-        this.totalQuestions = totalQuestions;
-    }
-
-    public String getCreatedDate() {
-        return createdDate;
-    }
-
-    public void setCreatedDate(String createdDate) {
-        this.createdDate = createdDate;
-    }
-
-    public String getSolvedDate() {
-        return solvedDate;
-    }
-
-    public void setSolvedDate(String solvedDate) {
-        this.solvedDate = solvedDate;
-    }
-
-    public String getAnswerSummary() {
-        return answerSummary;
-    }
-
-    public void setAnswerSummary(String answerSummary) {
-        this.answerSummary = answerSummary;
-    }
-
-    public String getCategoryName() {
-        return categoryName;
-    }
-
-    public void setCategoryName(String categoryName) {
-        this.categoryName = categoryName;
-    }
-
-    public String getParentCategoryName() {
-        return parentCategoryName;
-    }
-
-    public void setParentCategoryName(String parentCategoryName) {
-        this.parentCategoryName = parentCategoryName;
+        return correctCount > wrongCount
+                ? "정답 " + correctCount + "문제"
+                : "오답 " + wrongCount + "문제";
     }
 }

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizRepository.java
@@ -1,6 +1,8 @@
 package QRAB.QRAB.quiz.repository;
 
 import QRAB.QRAB.quiz.domain.Quiz;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizSetRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizSetRepository.java
@@ -1,5 +1,6 @@
 package QRAB.QRAB.quiz.repository;
 
+import QRAB.QRAB.quiz.domain.Quiz;
 import QRAB.QRAB.quiz.domain.QuizSet;
 import QRAB.QRAB.user.domain.User;
 import org.springframework.data.domain.Page;
@@ -11,4 +12,5 @@ import org.springframework.stereotype.Repository;
 public interface QuizSetRepository extends JpaRepository<QuizSet, Long> {
     // status가 'unsolved'인 퀴즈세트만 조회
     Page<QuizSet> findByUserAndStatus(User user, String status, Pageable pageable);
+    Page<QuizSet> findByNoteIdAndStatus(Long noteId, String status, Pageable pageable);
 }


### PR DESCRIPTION
- noteId로 solved 퀴즈 세트 조회 기능 구현
- 카테고리 별 조회 API에 /quiz-lab/quizzes/{categoryId} 엔드포인트 추가
- 변수명 수정: createdDate -> createdAt, solvedDate -> solvedAt