### PR TITLE
feat: 특정 노트 unsolved 퀴즈 세트 조회 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
@@ -46,12 +46,14 @@ public class QuizController {
         return ResponseEntity.ok(storedNotes);
     }
 
+    // 카테고리 별 노트 조회 엔드포인트 추가
     @GetMapping("/quizzes/{categoryId}")
     public ResponseEntity<?> getNotePageByCategoryInQuizLab(@PathVariable("categoryId") Long categoryId,
                                                             @RequestParam(name = "page", defaultValue = "0") int page) {
         return noteController.getNotePageByCategory(categoryId, page);
     }
 
+    // 특정 noteId를 가지는 solved 퀴즈 세트 조회 엔드포인트
     @GetMapping("/quizzes/{noteId}/solved")
     public ResponseEntity<Page<QuizResultDTO>> getSolvedQuizSetsByNoteId(
             @PathVariable("noteId") Long noteId,
@@ -60,7 +62,7 @@ public class QuizController {
         return ResponseEntity.ok(solvedQuizSets);
     }
 
-    // status가 solved인 퀴즈 세트 조회 엔드포인트 (퀴즈 저장소 화면용)
+    // solved 퀴즈 세트 조회 엔드포인트 (퀴즈 저장소 화면용)
     @GetMapping("/quizzes/solved")
     public ResponseEntity<Page<QuizResultDTO>> getSolvedQuizSets(
             @RequestParam(name = "page", defaultValue = "0") int page) {

--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizSolvingController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizSolvingController.java
@@ -1,9 +1,6 @@
 package QRAB.QRAB.quiz.controller;
 
-import QRAB.QRAB.quiz.dto.QuizGradingRequestDTO;
-import QRAB.QRAB.quiz.dto.QuizGradingResponseDTO;
-import QRAB.QRAB.quiz.dto.QuizSolvingResponseDTO;
-import QRAB.QRAB.quiz.dto.UnsolvedQuizSetResponseDTO;
+import QRAB.QRAB.quiz.dto.*;
 import QRAB.QRAB.quiz.service.QuizService;
 import QRAB.QRAB.quiz.service.QuizSolvingService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,10 +22,19 @@ public class QuizSolvingController {
     }
 
     // 퀴즈 풀기 전체 퀴즈세트 조회
-    @GetMapping
+    @GetMapping("/all/quizzes")
     public ResponseEntity<Page<UnsolvedQuizSetResponseDTO>> findUnsolvedQuizSets(
             @RequestParam(name = "page", defaultValue = "0") int page) {
         Page<UnsolvedQuizSetResponseDTO> unsolvedQuizSets = quizService.findUnsolvedQuizSets(page);
+        return ResponseEntity.ok(unsolvedQuizSets);
+    }
+
+    // 특정 노트 unsolved 퀴즈 세트 조회
+    @GetMapping("/{noteId}/unsolved")
+    public ResponseEntity<Page<QuizSetDTO>> getUnsolvedQuizSetsByNoteId(
+            @PathVariable Long noteId,
+            @RequestParam(name = "page", defaultValue = "0") int page) {
+        Page<QuizSetDTO> unsolvedQuizSets = quizService.findUnsolvedQuizSetsByNoteId(noteId, page);
         return ResponseEntity.ok(unsolvedQuizSets);
     }
 

--- a/src/main/java/QRAB/QRAB/quiz/dto/QuizSetDTO.java
+++ b/src/main/java/QRAB/QRAB/quiz/dto/QuizSetDTO.java
@@ -23,6 +23,17 @@ public class QuizSetDTO {
         this.accuracyRate = quizSet.getAccuracyRate();
     }
 
+    public QuizSetDTO(Long quizSetId, Long noteId, Long userId, int totalQuestions,
+                      LocalDateTime createdAt, String status, float accuracyRate) {
+        this.quizSetId = quizSetId;
+        this.noteId = noteId;
+        this.userId = userId;
+        this.totalQuestions = totalQuestions;
+        this.createdAt = createdAt;
+        this.status = status;
+        this.accuracyRate = accuracyRate;
+    }
+
     public Long getQuizSetId() {
         return quizSetId;
     }

--- a/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
+++ b/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
@@ -246,11 +246,28 @@ public class QuizService {
         );
     }
 
+    // 특정 노트 unsolved 퀴즈 세트 조회
+    public Page<QuizSetDTO> findUnsolvedQuizSetsByNoteId(Long noteId, int page) {
+        Pageable pageable = PageRequest.of(page, 6); // 한 페이지에 6개로 설정
+        Page<QuizSet> unsolvedQuizSets = quizSetRepository.findByNoteIdAndStatus(noteId, "unsolved", pageable);
+
+        return unsolvedQuizSets.map(quizSet -> new QuizSetDTO(
+                quizSet.getQuizSetId(),
+                quizSet.getNote() != null ? quizSet.getNote().getId() : null,
+                quizSet.getUser() != null ? quizSet.getUser().getUserId() : null,
+                quizSet.getTotalQuestions(),
+                quizSet.getCreatedAt(),
+                quizSet.getStatus(),
+                quizSet.getAccuracyRate()
+        ));
+    }
+
+    // 오답 복습 퀴즈 조회
     public ReviewWrongQuizDTO getReviewWrongQuizzesByQuizSetId(Long quizSetId) {
         QuizSet quizSet = quizSetRepository.findById(quizSetId)
                 .orElseThrow(() -> new EntityNotFoundException("QuizSet not found with id: " + quizSetId));
 
-        // `quizSetId`에 속한 오답 퀴즈만 조회
+        // 'quizSetId'에 속한 오답 퀴즈만 조회
         List<Quiz> incorrectQuizzes = quizAnswerRepository.findIncorrectAnswersByQuizSetId(quizSetId).stream()
                 .map(QuizAnswer::getQuiz)
                 .distinct() // 중복 퀴즈 제거
@@ -270,6 +287,7 @@ public class QuizService {
         return new ReviewWrongQuizDTO(quizSet.getNote().getTitle(), quizDetails);
     }
 
+    // 오답 복습 퀴즈 채점
     public QuizGradingResponseDTO gradeReviewWrongQuiz(Long quizSetId, QuizGradingRequestDTO requestDTO) {
         QuizSet quizSet = quizSetRepository.findById(quizSetId)
                 .orElseThrow(() -> new EntityNotFoundException("QuizSet not found with id: " + quizSetId));


### PR DESCRIPTION
- noteId를 통해 해당 노트의 unsolved 퀴즈 세트를 조회하는 기능 구현
- 한 페이지에 6개씩 페이지네이션
- 사용하지 않는 API의 사용을 막기 위해 퀴즈 풀기 전체 퀴즈 세트 조회 API 엔드포인트 변경