### PR TITLE
feat: 최근 틀린 퀴즈 조회 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
@@ -93,4 +93,11 @@ public class QuizController {
         return ResponseEntity.ok(response);
     }
 
+    // 최근 틀린 퀴즈 조회 엔드포인트
+    @GetMapping("/recent-wrong")
+    public ResponseEntity<List<RecentWrongQuizDTO>> getRecentWrongQuizzes() {
+        List<RecentWrongQuizDTO> recentWrongQuizzes = quizService.getRecentWrongQuizzes();
+        return ResponseEntity.ok(recentWrongQuizzes);
+    }
+
 }

--- a/src/main/java/QRAB/QRAB/quiz/domain/QuizAnswer.java
+++ b/src/main/java/QRAB/QRAB/quiz/domain/QuizAnswer.java
@@ -20,6 +20,10 @@ public class QuizAnswer {
     @JoinColumn(name = "quiz_id", nullable = false)
     private Quiz quiz;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_set_id")
+    private QuizSet quizSet;
+
     private int selectedAnswer;
     private boolean isCorrect;
 

--- a/src/main/java/QRAB/QRAB/quiz/dto/RecentWrongQuizDTO.java
+++ b/src/main/java/QRAB/QRAB/quiz/dto/RecentWrongQuizDTO.java
@@ -1,0 +1,21 @@
+package QRAB.QRAB.quiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecentWrongQuizDTO {
+    private Long quizId;
+    private String question;
+    private List<String> choices;
+    private int selectedAnswer;
+    private int correctAnswer;
+    private boolean isCorrect;
+}
+

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizAnswerRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizAnswerRepository.java
@@ -2,6 +2,7 @@ package QRAB.QRAB.quiz.repository;
 
 import QRAB.QRAB.quiz.domain.QuizAnswer;
 import QRAB.QRAB.quiz.domain.QuizResult;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,5 +19,9 @@ public interface QuizAnswerRepository extends JpaRepository<QuizAnswer, Long> {
             "JOIN q.quizSet qs " +
             "WHERE qs.quizSetId = :quizSetId AND qa.isCorrect = false")
     List<QuizAnswer> findIncorrectAnswersByQuizSetId(@Param("quizSetId") Long quizSetId);
+
+    // 최근 틀린 퀴즈 조회
+    @Query("SELECT qa FROM QuizAnswer qa WHERE qa.isCorrect = false ORDER BY qa.quizSet.createdAt DESC")
+    List<QuizAnswer> findRecentWrongAnswers();
 }
 

--- a/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
+++ b/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
@@ -334,4 +334,22 @@ public class QuizService {
 
         return responseDTO;
     }
+
+    // 최근 틀린 퀴즈 2개 조회
+    public List<RecentWrongQuizDTO> getRecentWrongQuizzes() {
+        List<QuizAnswer> recentWrongAnswers = quizAnswerRepository.findRecentWrongAnswers();
+
+        return recentWrongAnswers.stream()
+                .limit(2) // 최근 틀린 퀴즈 2개만 반환
+                .map(answer -> new RecentWrongQuizDTO(
+                        answer.getQuiz().getQuizId(),
+                        answer.getQuiz().getQuestion(),
+                        answer.getQuiz().getChoicesAsList(),
+                        answer.getSelectedAnswer(),
+                        answer.getQuiz().getCorrectAnswer(),
+                        answer.isCorrect()
+                ))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/QRAB/QRAB/quiz/service/QuizSolvingService.java
+++ b/src/main/java/QRAB/QRAB/quiz/service/QuizSolvingService.java
@@ -116,6 +116,7 @@ public class QuizSolvingService {
             QuizAnswer quizAnswer = new QuizAnswer();
             quizAnswer.setQuizResult(quizResult); // QuizResult 설정
             quizAnswer.setQuiz(quiz);
+            quizAnswer.setQuizSet(quiz.getQuizSet());
             quizAnswer.setSelectedAnswer(answer.getSelectedAnswer());
             quizAnswer.setIsCorrect(isCorrect);
             quizAnswerRepository.save(quizAnswer);


### PR DESCRIPTION
- 최근 틀린 퀴즈를 2개 조회하는 기능 구현
- quiz_answer 엔티티에 quiz_set_id 필드 추가
- quiz_answer에 저장 시에 quiz_set_id도 저장하도록 변경