### PR TITLE
feat: 응용 퀴즈 생성 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/bookmark/service/BookmarkService.java
+++ b/src/main/java/QRAB/QRAB/bookmark/service/BookmarkService.java
@@ -5,6 +5,7 @@ import QRAB.QRAB.bookmark.dto.BookmarkRequestDTO;
 import QRAB.QRAB.bookmark.dto.BookmarkResponseDTO;
 import QRAB.QRAB.bookmark.repository.BookmarkRepository;
 import QRAB.QRAB.quiz.domain.Quiz;
+import QRAB.QRAB.quiz.repository.QuizAnswerRepository;
 import QRAB.QRAB.quiz.repository.QuizRepository;
 import QRAB.QRAB.user.domain.User;
 import QRAB.QRAB.user.repository.UserRepository;
@@ -19,13 +20,15 @@ import java.time.LocalDateTime;
 public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
+    private final QuizAnswerRepository quizAnswerRepository;
     private final QuizRepository quizRepository;
     private final UserRepository userRepository;
 
     @Autowired
-    public BookmarkService(BookmarkRepository bookmarkRepository, QuizRepository quizRepository, UserRepository userRepository) {
+    public BookmarkService(BookmarkRepository bookmarkRepository, QuizRepository quizRepository, QuizAnswerRepository quizAnswerRepository, UserRepository userRepository) {
         this.bookmarkRepository = bookmarkRepository;
         this.quizRepository = quizRepository;
+        this.quizAnswerRepository = quizAnswerRepository;
         this.userRepository = userRepository;
     }
 
@@ -34,8 +37,9 @@ public class BookmarkService {
         User user = userRepository.findOneWithAuthoritiesByUsername(username)
                 .orElseThrow(() -> new RuntimeException("User not found: " + username));
 
-        Quiz quiz = quizRepository.findById(requestDTO.getQuizId())
-                .orElseThrow(() -> new RuntimeException("Quiz not found: " + requestDTO.getQuizId()));
+        Quiz quiz = quizAnswerRepository.findByQuizIdAndIsCorrectFalse(requestDTO.getQuizId())
+                .orElseThrow(() -> new RuntimeException("Incorrect quiz not found for quizId: " + requestDTO.getQuizId()))
+                .getQuiz();
 
         // 북마크 객체 생성
         Bookmark bookmark = new Bookmark();

--- a/src/main/java/QRAB/QRAB/chatgpt/service/ChatgptService.java
+++ b/src/main/java/QRAB/QRAB/chatgpt/service/ChatgptService.java
@@ -68,7 +68,7 @@ public class ChatgptService {
 
         return chatgptResponseDTO != null ? chatgptResponseDTO.getFirstChoiceContent() : "";
     }
-    // 퀴즈 생성
+    // 퀴즈 생성, 응용 퀴즈 생성
     public List<Quiz> generateQuiz(String quizPrompt) {
         ChatgptRequestDTO chatgptRequestDTO = new ChatgptRequestDTO(model, quizPrompt);
         ChatgptResponseDTO chatgptResponseDTO = restTemplate.postForObject(apiUrl, chatgptRequestDTO, ChatgptResponseDTO.class);

--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
@@ -100,4 +100,11 @@ public class QuizController {
         return ResponseEntity.ok(recentWrongQuizzes);
     }
 
+    // 응용 퀴즈 생성 엔드포인트
+    @PostMapping("/regenerate")
+    public ResponseEntity<QuizSetDTO> regenerateQuiz(@RequestBody QuizRegenerationRequestDTO request) {
+        QuizSetDTO quizSetResponse = quizService.regenerateQuiz(request);
+        return ResponseEntity.ok(quizSetResponse);
+    }
+
 }

--- a/src/main/java/QRAB/QRAB/quiz/domain/Quiz.java
+++ b/src/main/java/QRAB/QRAB/quiz/domain/Quiz.java
@@ -1,5 +1,6 @@
 package QRAB.QRAB.quiz.domain;
 
+import QRAB.QRAB.note.domain.Note;
 import jakarta.persistence.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,9 +24,17 @@ public class Quiz {
     private String explanation;
     private String quizSummary;
 
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<QuizAnswer> quizAnswers;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "quiz_set_id")
     private QuizSet quizSet;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "note_id")
+    private Note note;
+
 
     // Choices를 리스트로 변환
     public List<String> getChoicesAsList() {

--- a/src/main/java/QRAB/QRAB/quiz/dto/QuizRegenerationRequestDTO.java
+++ b/src/main/java/QRAB/QRAB/quiz/dto/QuizRegenerationRequestDTO.java
@@ -1,0 +1,12 @@
+package QRAB.QRAB.quiz.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class QuizRegenerationRequestDTO {
+    private Long noteId;
+    private int totalQuestions;
+    private String quizType; // "new" 또는 "review"
+}

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizAnswerRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizAnswerRepository.java
@@ -1,5 +1,6 @@
 package QRAB.QRAB.quiz.repository;
 
+import QRAB.QRAB.note.domain.Note;
 import QRAB.QRAB.quiz.domain.QuizAnswer;
 import QRAB.QRAB.quiz.domain.QuizResult;
 import org.springframework.data.domain.Pageable;
@@ -9,16 +10,25 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface QuizAnswerRepository extends JpaRepository<QuizAnswer, Long> {
     List<QuizAnswer> findByQuizResult(QuizResult quizResult);
+    List<QuizAnswer> findByQuiz_QuizIdAndIsCorrectFalse(Note note);
     // quizSetId로 오답 조회
     @Query("SELECT qa FROM QuizAnswer qa " +
             "JOIN qa.quiz q " +
             "JOIN q.quizSet qs " +
             "WHERE qs.quizSetId = :quizSetId AND qa.isCorrect = false")
     List<QuizAnswer> findIncorrectAnswersByQuizSetId(@Param("quizSetId") Long quizSetId);
+
+    @Query("SELECT qa FROM QuizAnswer qa WHERE qa.quiz.note.id = :noteId AND qa.isCorrect = false")
+    List<QuizAnswer> findIncorrectAnswersByNoteId(@Param("noteId") Long noteId);
+
+    @Query("SELECT qa FROM QuizAnswer qa WHERE qa.quiz.quizId = :quizId AND qa.isCorrect = false")
+    Optional<QuizAnswer> findByQuizIdAndIsCorrectFalse(@Param("quizId") Long quizId);
+
 
     // 최근 틀린 퀴즈 조회
     @Query("SELECT qa FROM QuizAnswer qa WHERE qa.isCorrect = false ORDER BY qa.quizSet.createdAt DESC")

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizRepository.java
@@ -4,6 +4,8 @@ import QRAB.QRAB.quiz.domain.Quiz;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +13,7 @@ import java.util.List;
 @Repository
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
     List<Quiz> findByQuizSet_QuizSetId(Long quizSetId);
+
+    @Query("SELECT DISTINCT q FROM Quiz q JOIN q.quizAnswers qa WHERE q.note.id = :noteId AND qa.isCorrect = false")
+    List<Quiz> findQuizzesWithIncorrectAnswers(@Param("noteId") Long noteId);
 }

--- a/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
+++ b/src/main/java/QRAB/QRAB/quiz/service/QuizService.java
@@ -5,6 +5,7 @@ import QRAB.QRAB.quiz.domain.QuizResult;
 import QRAB.QRAB.quiz.dto.*;
 import QRAB.QRAB.quiz.domain.Quiz;
 import QRAB.QRAB.quiz.domain.QuizSet;
+import QRAB.QRAB.quiz.dto.QuizRegenerationRequestDTO;
 import QRAB.QRAB.chatgpt.service.ChatgptService;
 import QRAB.QRAB.quiz.repository.QuizAnswerRepository;
 import QRAB.QRAB.quiz.repository.QuizRepository;
@@ -364,5 +365,80 @@ public class QuizService {
         List<UnsolvedRecentQuizSetDTO> unsolvedRecentQuizSetDTOS = quizSets.stream()
                 .limit(3).map(UnsolvedRecentQuizSetDTO::fromEntity).toList();
         return unsolvedRecentQuizSetDTOS;
+    }
+
+    public QuizSetDTO regenerateQuiz(QuizRegenerationRequestDTO request) {
+        if ("new".equals(request.getQuizType())) {
+            // "new" 타입인 경우 기존 createQuizSet 호출
+            QuizGenerationRequestDTO generationRequestDTO = new QuizGenerationRequestDTO();
+            generationRequestDTO.setNoteId(request.getNoteId());
+            generationRequestDTO.setTotalQuestions(request.getTotalQuestions());
+            return createQuizSet(generationRequestDTO);
+        }
+
+        // "review" 타입인 경우 기존 로직 실행
+        Note note = noteRepository.findById(request.getNoteId())
+                .orElseThrow(() -> new EntityNotFoundException("Note not found with id: " + request.getNoteId()));
+
+        // 틀린 문제의 QuizSummary를 수집하여 프롬프트 생성
+        List<String> quizSummaries = quizAnswerRepository.findIncorrectAnswersByNoteId(request.getNoteId())
+                .stream()
+                .map(QuizAnswer::getQuiz) // QuizAnswer에서 Quiz 객체 가져오기
+                .map(Quiz::getQuizSummary) // Quiz 객체에서 QuizSummary 추출
+                .collect(Collectors.toList());
+
+        String regenQuizPrompt = String.format(
+                "다음은 사용자가 이전에 틀린 문제와 유사한 주제의 문제를 생성하는 요청입니다. 퀴즈는 객관식 사지선다형이며, 각 퀴즈에 대해 난이도, 질문, 선택지, 정답, 풀이, 퀴즈 요약을 포함해 주세요. 총 %d개의 퀴즈를 생성해 주세요.\n\n" +
+                        "해당 노트의 주제는 다음과 같습니다:\n\n" +
+                        "- 노트 제목: %s\n" +
+                        "난이도를 책정하는 기준은 다음과 같습니다:\n" +
+                        "- easy: 주제에 대한 기본 개념을 묻고 있음. 10명 중 8명 이상의 정답자가 예상됨.\n" +
+                        "- medium: 주제에 대한 심화 개념이나 더 깊은 이해를 요구함. 10명 중 5명 이하의 정답자가 예상됨.\n" +
+                        "- hard: 주제에 대해 medium 난이도보다 더 깊은 이해를 요구함. 10명 중 3명 이하의 정답자가 예상됨.\n\n" +
+                        "이전 틀린 문제들의 내용을 바탕으로 유사한 퀴즈를 생성해 주세요.\n\n" +
+                        "각 퀴즈의 형식은 JSON 형식으로 다음과 같이 작성해 주세요:\n" +
+                        "{\n" +
+                        "  \"difficulty\": \"난이도 (easy, medium, hard 중 하나)\",\n" +
+                        "  \"question\": \"퀴즈 질문 내용\",\n" +
+                        "  \"choices\": [\n" +
+                        "    \"a. 선택지 1\",\n" +
+                        "    \"b. 선택지 2\",\n" +
+                        "    \"c. 선택지 3\",\n" +
+                        "    \"d. 선택지 4\"\n" +
+                        "  ],\n" +
+                        "  \"correct_answer\": \"정답의 선택지 번호 (0부터 시작하여 0, 1, 2, 3 중 하나)\",\n" +
+                        "  \"explanation\": \"정답 풀이\",\n" +
+                        "  \"quiz_summary\": \"퀴즈 요약\"\n" +
+                        "}\n" +
+                        "정답의 선택지 번호는 0, 1, 2, 3이 고루 분포되어야 합니다.\n\n" +
+                        "다음은 이전에 틀렸던 퀴즈의 내용 요약입니다. 반드시 이 내용에 관한 퀴즈를 %d개 출제하고, JSON 형식의 앞뒤에 아무 말도 덧붙이지 말고 JSON 형식으로만 반환해 주세요.\n\n" +
+                        "%s\n\n" +
+                        "내용 요약이 끝났습니다. 가장 중요한 것은 **꼭 틀린 문제와 유사한 주제, 내용으로** **앞뒤에 아무 말도 없이** **JSON 형식**으로 **%d개의 퀴즈**를 출제하는 것입니다.",
+                request.getTotalQuestions(),
+                note.getTitle(),
+                request.getTotalQuestions(),
+                String.join("\n", quizSummaries),
+                request.getTotalQuestions()
+        );
+
+        // GPT 호출하여 퀴즈 생성
+        List<Quiz> quizzes = chatgptService.generateQuiz(regenQuizPrompt);
+
+        // QuizSet 생성 및 저장
+        QuizSet quizSet = new QuizSet();
+        quizSet.setNote(note);
+        quizSet.setUser(note.getUser());
+        quizSet.setTotalQuestions(request.getTotalQuestions());
+        quizSet.setCreatedAt(LocalDateTime.now());
+        quizSet.setStatus("unsolved");
+        quizSetRepository.save(quizSet);
+
+        // 생성된 퀴즈를 데이터베이스에 저장
+        for (Quiz quiz : quizzes) {
+            quiz.setQuizSet(quizSet);
+            quizRepository.save(quiz);
+        }
+
+        return new QuizSetDTO(quizSet);
     }
 }


### PR DESCRIPTION
- noteId를 통해 해당 노트의 틀린 퀴즈의 quiz_summary를 기반으로 응용 퀴즈를 생성하도록 구현
- quiz_type이 new이면 기존 퀴즈 생성 로직, quiz_type이 review이면 응용 퀴즈 생성 로직을 따라가도록 구현