### PR TITLE
feat: 이번 달 통계 조회 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/analysis/controller/AnalysisController.java
+++ b/src/main/java/QRAB/QRAB/analysis/controller/AnalysisController.java
@@ -1,0 +1,36 @@
+package QRAB.QRAB.analysis.controller;
+
+import QRAB.QRAB.analysis.dto.MonthlyAnalysisResponseDTO;
+import QRAB.QRAB.analysis.service.AnalysisService;
+import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.user.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/analysis")
+public class AnalysisController {
+
+    private final AnalysisService analysisService;
+    private final UserRepository userRepository; // UserRepository 주입
+
+    public AnalysisController(AnalysisService analysisService, UserRepository userRepository) {
+        this.analysisService = analysisService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/monthly")
+    public ResponseEntity<MonthlyAnalysisResponseDTO> getMonthlyStats(
+            @RequestParam("year") int year,
+            @RequestParam("month") int month
+    ) {
+        MonthlyAnalysisResponseDTO response = analysisService.getMonthlyAnalysis(year, month);
+        return ResponseEntity.ok(response);
+    }
+
+}
+

--- a/src/main/java/QRAB/QRAB/analysis/domain/CategoryAnalysis.java
+++ b/src/main/java/QRAB/QRAB/analysis/domain/CategoryAnalysis.java
@@ -1,0 +1,34 @@
+package QRAB.QRAB.analysis.domain;
+
+import QRAB.QRAB.category.domain.Category;
+import QRAB.QRAB.user.domain.User;
+import lombok.Data;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "category_analysis")
+@Data
+public class CategoryAnalysis {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryAnalysisId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(nullable = false, length = 7)
+    private String month; // YYYY-MM 형식
+
+    @Column(nullable = false)
+    private int solvedQuizCount;
+
+    @Column(nullable = false)
+    private float categoryAccuracy;
+}
+

--- a/src/main/java/QRAB/QRAB/analysis/domain/DailyAnalysis.java
+++ b/src/main/java/QRAB/QRAB/analysis/domain/DailyAnalysis.java
@@ -1,0 +1,40 @@
+package QRAB.QRAB.analysis.domain;
+
+import QRAB.QRAB.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class DailyAnalysis {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long dailyAnalysisId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private int solvedQuizCount;
+
+    @Column(nullable = false)
+    private float averageAccuracy;
+
+    public DailyAnalysis(User user, LocalDate date, int solvedQuizCount, float averageAccuracy) {
+        this.user = user;
+        this.date = date;
+        this.solvedQuizCount = solvedQuizCount;
+        this.averageAccuracy = averageAccuracy;
+    }
+}

--- a/src/main/java/QRAB/QRAB/analysis/domain/MonthlyAnalysis.java
+++ b/src/main/java/QRAB/QRAB/analysis/domain/MonthlyAnalysis.java
@@ -1,0 +1,42 @@
+package QRAB.QRAB.analysis.domain;
+
+import QRAB.QRAB.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class MonthlyAnalysis {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long monthlyAnalysisId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 7)
+    private String month; // YYYY-MM 형식
+
+    @Column(nullable = false)
+    private int solvedQuizCount;
+
+    @Column(nullable = false)
+    private int learningDays;
+
+    @Column(nullable = false)
+    private float averageAccuracy;
+
+    public MonthlyAnalysis(User user, String month, int solvedQuizCount, int learningDays, float averageAccuracy) {
+        this.user = user;
+        this.month = month;
+        this.solvedQuizCount = solvedQuizCount;
+        this.learningDays = learningDays;
+        this.averageAccuracy = averageAccuracy;
+    }
+}

--- a/src/main/java/QRAB/QRAB/analysis/dto/CategoryAnalysisDTO.java
+++ b/src/main/java/QRAB/QRAB/analysis/dto/CategoryAnalysisDTO.java
@@ -1,0 +1,15 @@
+package QRAB.QRAB.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryAnalysisDTO {
+    private String parentCategoryName;
+    private String categoryName;
+    private int solvedQuizCount;
+    private float categoryAccuracy;
+}

--- a/src/main/java/QRAB/QRAB/analysis/dto/MonthlyAnalysisResponseDTO.java
+++ b/src/main/java/QRAB/QRAB/analysis/dto/MonthlyAnalysisResponseDTO.java
@@ -1,0 +1,18 @@
+package QRAB.QRAB.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MonthlyAnalysisResponseDTO {
+    private int learningDays;
+    private int solvedQuizCount;
+    private float averageAccuracy;
+    private List<CategoryAnalysisDTO> categories;
+}
+

--- a/src/main/java/QRAB/QRAB/analysis/repository/CategoryAnalysisRepository.java
+++ b/src/main/java/QRAB/QRAB/analysis/repository/CategoryAnalysisRepository.java
@@ -1,0 +1,20 @@
+package QRAB.QRAB.analysis.repository;
+
+import QRAB.QRAB.analysis.domain.CategoryAnalysis;
+import QRAB.QRAB.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CategoryAnalysisRepository extends JpaRepository<CategoryAnalysis, Long> {
+
+    @Query("SELECT ca FROM CategoryAnalysis ca WHERE ca.user = :user AND ca.month = :month")
+    List<CategoryAnalysis> findByUserAndMonth(@Param("user") User user, @Param("month") String month);
+
+    @Query("SELECT ca FROM CategoryAnalysis ca WHERE ca.user = :user AND ca.category.id = :categoryId AND ca.month = :month")
+    Optional<CategoryAnalysis> findByUserAndCategoryAndMonth(@Param("user") User user, @Param("categoryId") Long categoryId, @Param("month") String month);
+
+}

--- a/src/main/java/QRAB/QRAB/analysis/repository/DailyAnalysisRepository.java
+++ b/src/main/java/QRAB/QRAB/analysis/repository/DailyAnalysisRepository.java
@@ -1,0 +1,25 @@
+package QRAB.QRAB.analysis.repository;
+
+import QRAB.QRAB.analysis.domain.DailyAnalysis;
+import QRAB.QRAB.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyAnalysisRepository extends JpaRepository<DailyAnalysis, Long> {
+    Optional<DailyAnalysis> findByUserAndDate(User user, LocalDate date);
+
+    @Query("SELECT da FROM DailyAnalysis da WHERE da.user = :user AND FUNCTION('DATE_FORMAT', da.date, '%Y-%m') = :month")
+    List<DailyAnalysis> findByUserAndMonth(@Param("user") User user, @Param("month") String month);
+
+
+    @Query("SELECT SUM(da.solvedQuizCount) FROM DailyAnalysis da WHERE da.user = :user AND da.date BETWEEN :startDate AND :endDate")
+    int getTotalSolvedQuizCountBetweenDates(@Param("user") User user, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT AVG(da.averageAccuracy) FROM DailyAnalysis da WHERE da.user = :user AND da.date BETWEEN :startDate AND :endDate")
+    float getAverageAccuracyBetweenDates(@Param("user") User user, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+}

--- a/src/main/java/QRAB/QRAB/analysis/repository/MonthlyAnalysisRepository.java
+++ b/src/main/java/QRAB/QRAB/analysis/repository/MonthlyAnalysisRepository.java
@@ -1,0 +1,16 @@
+package QRAB.QRAB.analysis.repository;
+
+import QRAB.QRAB.analysis.domain.MonthlyAnalysis;
+import QRAB.QRAB.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MonthlyAnalysisRepository extends JpaRepository<MonthlyAnalysis, Long> {
+
+    Optional<MonthlyAnalysis> findByUserAndMonth(User user, String month);
+}
+
+

--- a/src/main/java/QRAB/QRAB/analysis/service/AnalysisService.java
+++ b/src/main/java/QRAB/QRAB/analysis/service/AnalysisService.java
@@ -1,0 +1,69 @@
+package QRAB.QRAB.analysis.service;
+
+import QRAB.QRAB.analysis.domain.MonthlyAnalysis;
+import QRAB.QRAB.analysis.dto.MonthlyAnalysisResponseDTO;
+import QRAB.QRAB.analysis.dto.CategoryAnalysisDTO;
+import QRAB.QRAB.analysis.repository.CategoryAnalysisRepository;
+import QRAB.QRAB.analysis.repository.MonthlyAnalysisRepository;
+import QRAB.QRAB.category.domain.Category;
+import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.user.repository.UserRepository;
+import QRAB.QRAB.user.util.SecurityUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AnalysisService {
+
+    private final MonthlyAnalysisRepository monthlyAnalysisRepository;
+    private final CategoryAnalysisRepository categoryAnalysisRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public AnalysisService(MonthlyAnalysisRepository monthlyAnalysisRepository,
+                           CategoryAnalysisRepository categoryAnalysisRepository,
+                           UserRepository userRepository) {
+        this.monthlyAnalysisRepository = monthlyAnalysisRepository;
+        this.categoryAnalysisRepository = categoryAnalysisRepository;
+        this.userRepository = userRepository;
+    }
+
+    public MonthlyAnalysisResponseDTO getMonthlyAnalysis(int year, int month) {
+        String username = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("인증된 사용자를 찾을 수 없습니다."));
+
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + username));
+
+        String formattedMonth = String.format("%d-%02d", year, month);
+
+        MonthlyAnalysis monthlyAnalysis = monthlyAnalysisRepository
+                .findByUserAndMonth(user, formattedMonth)
+                .orElseThrow(() -> new RuntimeException("월별 분석 데이터를 찾을 수 없습니다."));
+
+        List<CategoryAnalysisDTO> categories = categoryAnalysisRepository.findByUserAndMonth(user, formattedMonth).stream()
+                .map(categoryAnalysis -> new CategoryAnalysisDTO(
+                        categoryAnalysis.getCategory().getParentCategory() != null
+                                ? categoryAnalysis.getCategory().getParentCategory().getName()
+                                : null,
+                        categoryAnalysis.getCategory().getName(),
+                        categoryAnalysis.getSolvedQuizCount(),
+                        categoryAnalysis.getCategoryAccuracy()
+                ))
+                .collect(Collectors.toList());
+
+        return new MonthlyAnalysisResponseDTO(
+                monthlyAnalysis.getLearningDays(),
+                monthlyAnalysis.getSolvedQuizCount(),
+                monthlyAnalysis.getAverageAccuracy(),
+                categories
+        );
+    }
+}
+

--- a/src/main/java/QRAB/QRAB/analysis/service/CategoryAnalysisService.java
+++ b/src/main/java/QRAB/QRAB/analysis/service/CategoryAnalysisService.java
@@ -1,0 +1,52 @@
+package QRAB.QRAB.analysis.service;
+
+import QRAB.QRAB.analysis.domain.CategoryAnalysis;
+import QRAB.QRAB.analysis.repository.CategoryAnalysisRepository;
+import QRAB.QRAB.category.domain.Category;
+import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.user.repository.UserRepository;
+import QRAB.QRAB.user.util.SecurityUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategoryAnalysisService {
+
+    private final CategoryAnalysisRepository categoryAnalysisRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public CategoryAnalysisService(CategoryAnalysisRepository categoryAnalysisRepository,
+                                   UserRepository userRepository) {
+        this.categoryAnalysisRepository = categoryAnalysisRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void updateCategoryAnalysis(Long categoryId, String month, int solvedQuizCount, float accuracy) {
+        String username = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("인증된 사용자를 찾을 수 없습니다."));
+
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + username));
+
+        CategoryAnalysis categoryAnalysis = categoryAnalysisRepository
+                .findByUserAndCategoryAndMonth(user, categoryId, month)
+                .orElseGet(() -> {
+                    CategoryAnalysis newAnalysis = new CategoryAnalysis();
+                    newAnalysis.setUser(user);
+                    newAnalysis.setCategory(new Category(categoryId)); // Category 엔티티 참조
+                    newAnalysis.setMonth(month);
+                    newAnalysis.setSolvedQuizCount(0);
+                    newAnalysis.setCategoryAccuracy(0.0f);
+                    return newAnalysis;
+                });
+
+        categoryAnalysis.setSolvedQuizCount(categoryAnalysis.getSolvedQuizCount() + solvedQuizCount);
+        float totalAccuracy = (categoryAnalysis.getCategoryAccuracy() * categoryAnalysis.getSolvedQuizCount())
+                + (accuracy * solvedQuizCount);
+        categoryAnalysis.setCategoryAccuracy(totalAccuracy / (categoryAnalysis.getSolvedQuizCount() + solvedQuizCount));
+
+        categoryAnalysisRepository.save(categoryAnalysis);
+    }
+}
+

--- a/src/main/java/QRAB/QRAB/analysis/service/DailyAnalysisService.java
+++ b/src/main/java/QRAB/QRAB/analysis/service/DailyAnalysisService.java
@@ -1,0 +1,41 @@
+package QRAB.QRAB.analysis.service;
+
+import QRAB.QRAB.analysis.domain.DailyAnalysis;
+import QRAB.QRAB.analysis.repository.DailyAnalysisRepository;
+import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.user.util.SecurityUtil;
+import QRAB.QRAB.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+public class DailyAnalysisService {
+
+    private final DailyAnalysisRepository dailyAnalysisRepository;
+    private final UserRepository userRepository;
+
+    public DailyAnalysisService(DailyAnalysisRepository dailyAnalysisRepository, UserRepository userRepository) {
+        this.dailyAnalysisRepository = dailyAnalysisRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void updateDailyAnalysis(LocalDate date, int solvedQuizCount, float accuracy) {
+        String username = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("인증된 사용자를 찾을 수 없습니다."));
+
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + username));
+
+        DailyAnalysis dailyAnalysis = dailyAnalysisRepository.findByUserAndDate(user, date)
+                .orElseGet(() -> new DailyAnalysis(user, date, 0, 0.0f));
+
+        dailyAnalysis.setSolvedQuizCount(dailyAnalysis.getSolvedQuizCount() + solvedQuizCount);
+
+        float totalAccuracy = (dailyAnalysis.getAverageAccuracy() * dailyAnalysis.getSolvedQuizCount())
+                + (accuracy * solvedQuizCount);
+        dailyAnalysis.setAverageAccuracy(totalAccuracy / (dailyAnalysis.getSolvedQuizCount() + solvedQuizCount));
+
+        dailyAnalysisRepository.save(dailyAnalysis);
+    }
+}

--- a/src/main/java/QRAB/QRAB/analysis/service/MonthlyAnalysisService.java
+++ b/src/main/java/QRAB/QRAB/analysis/service/MonthlyAnalysisService.java
@@ -1,0 +1,73 @@
+package QRAB.QRAB.analysis.service;
+
+import QRAB.QRAB.analysis.domain.DailyAnalysis;
+import QRAB.QRAB.analysis.domain.MonthlyAnalysis;
+import QRAB.QRAB.analysis.repository.DailyAnalysisRepository;
+import QRAB.QRAB.analysis.repository.MonthlyAnalysisRepository;
+import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.user.repository.UserRepository;
+import QRAB.QRAB.user.util.SecurityUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+public class MonthlyAnalysisService {
+
+    private final MonthlyAnalysisRepository monthlyAnalysisRepository;
+    private final DailyAnalysisRepository dailyAnalysisRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public MonthlyAnalysisService(MonthlyAnalysisRepository monthlyAnalysisRepository,
+                                  DailyAnalysisRepository dailyAnalysisRepository,
+                                  UserRepository userRepository) {
+        this.monthlyAnalysisRepository = monthlyAnalysisRepository;
+        this.dailyAnalysisRepository = dailyAnalysisRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void updateMonthlyAnalysis(LocalDate date) {
+        // 인증된 사용자 가져오기
+        String username = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("인증된 사용자를 찾을 수 없습니다."));
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + username));
+
+        String currentMonth = date.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+
+        // DailyAnalysis 데이터를 기반으로 월별 통계 계산
+        List<DailyAnalysis> dailyAnalyses = dailyAnalysisRepository.findByUserAndMonth(user, currentMonth);
+
+        int totalSolvedQuizCount = dailyAnalyses.stream()
+                .mapToInt(DailyAnalysis::getSolvedQuizCount)
+                .sum();
+
+        // totalSolvedQuizCount가 0일 경우 예외 처리 (0으로 나누는 오류 방지)
+        if (totalSolvedQuizCount == 0) {
+            throw new RuntimeException("No quiz data found for the current month");
+        }
+
+        float totalAccuracy = (float) dailyAnalyses.stream()
+                .mapToDouble(daily -> daily.getAverageAccuracy() * daily.getSolvedQuizCount())
+                .sum() / totalSolvedQuizCount; // 정확도 평균 계산
+
+        int learningDays = dailyAnalyses.size(); // 학습 일수는 DailyAnalysis 개수로 계산
+
+        // 기존 MonthlyAnalysis 가져오거나 생성
+        MonthlyAnalysis monthlyAnalysis = monthlyAnalysisRepository.findByUserAndMonth(user, currentMonth)
+                .orElse(new MonthlyAnalysis(user, currentMonth, 0, 0, 0.0f));
+
+        // 통계 업데이트
+        monthlyAnalysis.setSolvedQuizCount(totalSolvedQuizCount);
+        monthlyAnalysis.setLearningDays(learningDays);
+        monthlyAnalysis.setAverageAccuracy(totalAccuracy);
+
+        // 저장
+        monthlyAnalysisRepository.save(monthlyAnalysis);
+    }
+}

--- a/src/main/java/QRAB/QRAB/category/domain/Category.java
+++ b/src/main/java/QRAB/QRAB/category/domain/Category.java
@@ -45,4 +45,12 @@ public class Category extends BaseTimeEntity {
         this.user = user;
         this.notes = notes != null ? notes : new ArrayList<>();
     }
+
+    public Category(Long categoryId) {
+        this.id = categoryId;
+    }
+
+    public void setCategoryId(Long categoryId) {
+        this.id = categoryId;
+    }
 }

--- a/src/main/java/QRAB/QRAB/chatgpt/service/ChatgptService.java
+++ b/src/main/java/QRAB/QRAB/chatgpt/service/ChatgptService.java
@@ -59,7 +59,7 @@ public class ChatgptService {
 
         String prompt = fewShotExamples + "\n\n" + content + """
         
-        Summarize this content in a concise, organized format like the above examples. When you print it out, don't get # or *, just get the text. Focus on key concepts and maintain logical flow. Make it as detailed and comprehensive as possible, enough to fill an A4 page.
+        Summarize this content in a concise, organized format like the above examples. When you print it out, don't get # or *, just get the text. Focus on key concepts and maintain logical flow. Make it as detailed and comprehensive as possible, enough to fill three pages. Be generous of the amount of the text.
         """;
 
         ChatgptRequestDTO chatgptRequestDTO = new ChatgptRequestDTO(model, prompt);


### PR DESCRIPTION
- year(yyyy)와 month(mm)를 통해 조회
- 그 달의 총 학습일 수, 푼 퀴즈 수, 평균 정답률, 그리고 각 카테고리 별로 푼 퀴즈 수와 정답률를 조회할 수 있도록 구현