### PR TITLE
feat: 월별 학습 기록 조회 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/analysis/controller/AnalysisController.java
+++ b/src/main/java/QRAB/QRAB/analysis/controller/AnalysisController.java
@@ -1,7 +1,9 @@
 package QRAB.QRAB.analysis.controller;
 
 import QRAB.QRAB.analysis.dto.MonthlyAnalysisResponseDTO;
+import QRAB.QRAB.analysis.dto.MonthlySummaryResponseDTO;
 import QRAB.QRAB.analysis.service.AnalysisService;
+import QRAB.QRAB.analysis.service.DailyAnalysisService;
 import QRAB.QRAB.user.domain.User;
 import QRAB.QRAB.user.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
@@ -16,11 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AnalysisController {
 
     private final AnalysisService analysisService;
-    private final UserRepository userRepository; // UserRepository 주입
+    private final DailyAnalysisService dailyAnalysisService;
 
-    public AnalysisController(AnalysisService analysisService, UserRepository userRepository) {
+    public AnalysisController(AnalysisService analysisService, DailyAnalysisService dailyAnalysisService) {
         this.analysisService = analysisService;
-        this.userRepository = userRepository;
+        this.dailyAnalysisService = dailyAnalysisService;
     }
 
     @GetMapping("/monthly")
@@ -29,6 +31,14 @@ public class AnalysisController {
             @RequestParam("month") int month
     ) {
         MonthlyAnalysisResponseDTO response = analysisService.getMonthlyAnalysis(year, month);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/monthly-summary")
+    public ResponseEntity<MonthlySummaryResponseDTO> getMonthlySummary(
+            @RequestParam("year") int year,
+            @RequestParam("month") int month) {
+        MonthlySummaryResponseDTO response = dailyAnalysisService.getMonthlySummary(year, month);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/QRAB/QRAB/analysis/dto/MonthlySummaryResponseDTO.java
+++ b/src/main/java/QRAB/QRAB/analysis/dto/MonthlySummaryResponseDTO.java
@@ -1,0 +1,22 @@
+package QRAB.QRAB.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class MonthlySummaryResponseDTO {
+    private int year;
+    private int month;
+    private List<DailyRecord> days;
+
+    @Data
+    @AllArgsConstructor
+    public static class DailyRecord {
+        private String date; // yyyy-mm-dd
+        private int solvedQuizCount;
+        private float dailyAccuracy;
+    }
+}

--- a/src/main/java/QRAB/QRAB/analysis/repository/DailyAnalysisRepository.java
+++ b/src/main/java/QRAB/QRAB/analysis/repository/DailyAnalysisRepository.java
@@ -16,7 +16,6 @@ public interface DailyAnalysisRepository extends JpaRepository<DailyAnalysis, Lo
     @Query("SELECT da FROM DailyAnalysis da WHERE da.user = :user AND FUNCTION('DATE_FORMAT', da.date, '%Y-%m') = :month")
     List<DailyAnalysis> findByUserAndMonth(@Param("user") User user, @Param("month") String month);
 
-
     @Query("SELECT SUM(da.solvedQuizCount) FROM DailyAnalysis da WHERE da.user = :user AND da.date BETWEEN :startDate AND :endDate")
     int getTotalSolvedQuizCountBetweenDates(@Param("user") User user, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 

--- a/src/main/java/QRAB/QRAB/analysis/service/DailyAnalysisService.java
+++ b/src/main/java/QRAB/QRAB/analysis/service/DailyAnalysisService.java
@@ -1,6 +1,7 @@
 package QRAB.QRAB.analysis.service;
 
 import QRAB.QRAB.analysis.domain.DailyAnalysis;
+import QRAB.QRAB.analysis.dto.MonthlySummaryResponseDTO;
 import QRAB.QRAB.analysis.repository.DailyAnalysisRepository;
 import QRAB.QRAB.user.domain.User;
 import QRAB.QRAB.user.util.SecurityUtil;
@@ -8,6 +9,8 @@ import QRAB.QRAB.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class DailyAnalysisService {
@@ -37,5 +40,27 @@ public class DailyAnalysisService {
         dailyAnalysis.setAverageAccuracy(totalAccuracy / (dailyAnalysis.getSolvedQuizCount() + solvedQuizCount));
 
         dailyAnalysisRepository.save(dailyAnalysis);
+    }
+
+    public MonthlySummaryResponseDTO getMonthlySummary(int year, int month) {
+        String username = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("인증된 사용자를 찾을 수 없습니다."));
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + username));
+
+        // 연월 조회 (yyyy-mm 형식)
+        String monthFormatted = String.format("%04d-%02d", year, month);
+        List<DailyAnalysis> dailyAnalyses = dailyAnalysisRepository.findByUserAndMonth(user, monthFormatted);
+
+        // DailyAnalysis -> DailyRecord 변환
+        List<MonthlySummaryResponseDTO.DailyRecord> dailyRecords = dailyAnalyses.stream()
+                .map(daily -> new MonthlySummaryResponseDTO.DailyRecord(
+                        daily.getDate().toString(),
+                        daily.getSolvedQuizCount(),
+                        daily.getAverageAccuracy()
+                ))
+                .toList();
+
+        return new MonthlySummaryResponseDTO(year, month, dailyRecords);
     }
 }

--- a/src/main/java/QRAB/QRAB/user/domain/User.java
+++ b/src/main/java/QRAB/QRAB/user/domain/User.java
@@ -42,7 +42,7 @@ public class User {
     private boolean activated;
 
     @Column(name = "notification")
-    private int notification; //알림 설정 기본값 0 -> 비공개
+    private Integer notification; //알림 설정 기본값 0 -> 비공개
 
     @ManyToMany
     @JoinTable(


### PR DESCRIPTION
- year(yyyy)와 month(mm)를 통해 조회
- 그 달의 학습일(yyyy-mm-dd)과 학습일 별 푼 퀴즈 수, 정답률을 조회할 수 있도록 구현