### PR TITLE
feat: 퀴즈 연구소 노트 저장소 조회 시 반환 내용 변경

### DIFF
--- a/src/main/java/QRAB/QRAB/note/dto/QuizLabNoteResponseDTO.java
+++ b/src/main/java/QRAB/QRAB/note/dto/QuizLabNoteResponseDTO.java
@@ -1,6 +1,8 @@
 package QRAB.QRAB.note.dto;
 
 import QRAB.QRAB.note.domain.Note;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,18 +15,13 @@ public class QuizLabNoteResponseDTO {
     private String categoryName;
     private String parentCategoryName;
     private String fileOrUrl;
-    private int quizGenerationCount; // 퀴즈 생성 횟수 추가
 
-    public static QuizLabNoteResponseDTO fromEntity(Note note) {
-        return new QuizLabNoteResponseDTO(
-                note.getId(),
-                note.getTitle(),
-                note.getChatgptContent().length() > 100 ? note.getChatgptContent().substring(0, 100) : note.getChatgptContent(),
-                note.getCategory().getName(),
-                note.getCategory().getParentCategory() != null ? note.getCategory().getParentCategory().getName() : "",
-                note.getUrl() != null ? note.getUrl() : note.getFile(),
-                note.getQuizGenerationCount() // 퀴즈 생성 횟수 가져오기
-        );
+    @JsonProperty("isSolved")
+    private boolean isSolved;
+
+    @JsonIgnore
+    public boolean getSolved() {
+        return isSolved;
     }
 }
 

--- a/src/main/java/QRAB/QRAB/note/dto/QuizSetDetailsDTO.java
+++ b/src/main/java/QRAB/QRAB/note/dto/QuizSetDetailsDTO.java
@@ -1,0 +1,11 @@
+package QRAB.QRAB.note.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuizSetDetailsDTO {
+    private Long quizSetId;
+    private String status;
+}

--- a/src/main/java/QRAB/QRAB/note/service/NoteService.java
+++ b/src/main/java/QRAB/QRAB/note/service/NoteService.java
@@ -5,14 +5,17 @@ import QRAB.QRAB.category.repository.CategoryRepository;
 import QRAB.QRAB.note.domain.Note;
 import QRAB.QRAB.note.dto.*;
 import QRAB.QRAB.note.repository.NoteRepository;
+import QRAB.QRAB.quiz.repository.QuizRepository;
 import QRAB.QRAB.user.domain.User;
 import QRAB.QRAB.user.repository.UserRepository;
+import QRAB.QRAB.user.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +30,7 @@ public class NoteService {
     private final NoteRepository noteRepository;
     private final UserRepository userRepository;
     public final CategoryRepository categoryRepository;
+    private final QuizRepository quizRepository;
 
     @Transactional(readOnly = true)
     public SummaryResponseDTO getNoteSummary(Long noteId){
@@ -135,18 +139,35 @@ public class NoteService {
         return recentNoteDTOS;
     }
 
-    // 추가: 퀴즈 연구소에서 사용될 저장된 노트 조회 메소드
+    // 퀴즈 연구소 저장된 노트 조회
+    public List<QuizLabNoteResponseDTO> getStoredNotesForQuizLab(int page) {
+        String username = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("현재 인증된 사용자가 없습니다."));
 
-    @Transactional(readOnly = true)
-    public List<QuizLabNoteResponseDTO> getStoredNotesForQuizLab(String username, int page) {
-        // SecurityContext에서 현재 인증된 사용자 정보 가져오기
         User user = userRepository.findOneWithAuthoritiesByUsername(username)
-                .orElseThrow(() -> new RuntimeException("Could not find user with email: " + username));
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
         Pageable pageable = PageRequest.of(page, 6, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Note> notes = noteRepository.findByUser(user, pageable);
 
         return notes.getContent().stream()
-                .map(QuizLabNoteResponseDTO::fromEntity)
+                .map(note -> {
+                    boolean isSolved = quizRepository.existsByNoteAndQuizSet_Status(note.getId(), "solved");
+                    System.out.println("Checking note ID: " + note.getId() + ", Result isSolved: " + isSolved);
+                    return new QuizLabNoteResponseDTO(
+                            note.getId(),
+                            note.getTitle(),
+                            note.getChatgptContent().length() > 100
+                                    ? note.getChatgptContent().substring(0, 100)
+                                    : note.getChatgptContent(),
+                            note.getCategory().getName(),
+                            note.getCategory().getParentCategory() != null
+                                    ? note.getCategory().getParentCategory().getName()
+                                    : "",
+                            note.getUrl(),
+                            isSolved
+                    );
+                })
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
+++ b/src/main/java/QRAB/QRAB/quiz/controller/QuizController.java
@@ -43,7 +43,7 @@ public class QuizController {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
 
         // 노트 목록 조회
-        List<QuizLabNoteResponseDTO> storedNotes = noteService.getStoredNotesForQuizLab(username, page);
+        List<QuizLabNoteResponseDTO> storedNotes = noteService.getStoredNotesForQuizLab(page);
         return ResponseEntity.ok(storedNotes);
     }
 

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizRepository.java
@@ -1,5 +1,6 @@
 package QRAB.QRAB.quiz.repository;
 
+import QRAB.QRAB.note.domain.Note;
 import QRAB.QRAB.quiz.domain.Quiz;
 import QRAB.QRAB.quiz.domain.QuizAnswer;
 import QRAB.QRAB.user.domain.User;
@@ -16,6 +17,11 @@ import java.util.List;
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
     List<Quiz> findByQuizSet_QuizSetId(Long quizSetId);
 
+    @Query("SELECT CASE WHEN COUNT(qs) > 0 THEN true ELSE false END " +
+            "FROM QuizSet qs " +
+            "WHERE qs.note.id = :noteId AND qs.status = :status")
+    boolean existsByNoteAndQuizSet_Status(@Param("noteId") Long noteId,
+                                          @Param("status") String status);
 
     @Query("SELECT DISTINCT q FROM Quiz q JOIN q.quizAnswers qa WHERE q.note.id = :noteId AND qa.isCorrect = false")
     List<Quiz> findQuizzesWithIncorrectAnswers(@Param("noteId") Long noteId);


### PR DESCRIPTION
- quizGenerationCount는 제외하고, isSolved를 반환하도록 변경
- isSolved는 해당 노트에 status가 solved인 퀴즈 세트가 하나라도 있을 경우 True, 전부 unsolved라면 False로 설정됨