### PR TITLE
feat: 상세 분석 생성/조회 기능 생성

### DIFF
--- a/src/main/java/QRAB/QRAB/analysis/controller/AnalysisController.java
+++ b/src/main/java/QRAB/QRAB/analysis/controller/AnalysisController.java
@@ -1,19 +1,17 @@
 package QRAB.QRAB.analysis.controller;
 
-import QRAB.QRAB.analysis.dto.CategoryAnalysisResponseDTO;
-import QRAB.QRAB.analysis.dto.MonthlyAnalysisResponseDTO;
-import QRAB.QRAB.analysis.dto.MonthlySummaryResponseDTO;
-import QRAB.QRAB.analysis.dto.WeakCategoryResponseDTO;
+import QRAB.QRAB.analysis.domain.DetailedAnalysis;
+import QRAB.QRAB.analysis.dto.*;
 import QRAB.QRAB.analysis.service.AnalysisService;
 import QRAB.QRAB.analysis.service.CategoryAnalysisService;
 import QRAB.QRAB.analysis.service.DailyAnalysisService;
+import QRAB.QRAB.analysis.service.DetailedAnalysisService;
+import QRAB.QRAB.user.util.SecurityUtil;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/analysis")
@@ -22,12 +20,14 @@ public class AnalysisController {
     private final AnalysisService analysisService;
     private final DailyAnalysisService dailyAnalysisService;
     private final CategoryAnalysisService categoryAnalysisService;
+    private final DetailedAnalysisService detailedAnalysisService;
 
     public AnalysisController(AnalysisService analysisService, DailyAnalysisService dailyAnalysisService,
-                              CategoryAnalysisService categoryAnalysisService) {
+                              CategoryAnalysisService categoryAnalysisService, DetailedAnalysisService detailedAnalysisService) {
         this.analysisService = analysisService;
         this.dailyAnalysisService = dailyAnalysisService;
         this.categoryAnalysisService = categoryAnalysisService;
+        this.detailedAnalysisService = detailedAnalysisService;
     }
 
     // 이번 달 통계 조회
@@ -62,6 +62,26 @@ public class AnalysisController {
     public ResponseEntity<WeakCategoryResponseDTO> getWeakCategoryAnalysis() {
         WeakCategoryResponseDTO response = categoryAnalysisService.getWeakCategoryAnalysis();
         System.out.println(response);
+        return ResponseEntity.ok(response);
+    }
+
+    // 상세 분석 수동 생성
+    @PostMapping("/detailed-analysis")
+    public ResponseEntity<DetailedAnalysisResponseDTO> createDetailedAnalysis() {
+        String username = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("No authenticated user found"));
+
+        DetailedAnalysisResponseDTO response = detailedAnalysisService.getDetailedAnalysis(username);
+        return ResponseEntity.ok(response);
+    }
+
+    // 상세 분석 조회
+    @GetMapping("/detailed-analysis/latest")
+    public ResponseEntity<DetailedAnalysisResponseDTO> getLatestDetailedAnalysis() {
+        String username = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new RuntimeException("No authenticated user found"));
+
+        DetailedAnalysisResponseDTO response = detailedAnalysisService.getLatestDetailedAnalysis(username);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/QRAB/QRAB/analysis/domain/CategoryAnalysis.java
+++ b/src/main/java/QRAB/QRAB/analysis/domain/CategoryAnalysis.java
@@ -14,21 +14,20 @@ public class CategoryAnalysis {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long categoryAnalysisId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
     @Column(nullable = false, length = 7)
     private String month; // YYYY-MM 형식
 
-    @Column(nullable = false)
     private int solvedQuizCount;
 
-    @Column(nullable = false)
     private float categoryAccuracy;
+
 }
 

--- a/src/main/java/QRAB/QRAB/analysis/domain/CategoryStrength.java
+++ b/src/main/java/QRAB/QRAB/analysis/domain/CategoryStrength.java
@@ -1,0 +1,34 @@
+package QRAB.QRAB.analysis.domain;
+
+import QRAB.QRAB.BaseTimeEntity;
+import QRAB.QRAB.category.domain.Category;
+import QRAB.QRAB.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "category_strength")
+public class CategoryStrength extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "strength_type")
+    private StrengthType strengthType;
+
+    public enum StrengthType {
+        STRONG, WEAK
+    }
+}

--- a/src/main/java/QRAB/QRAB/analysis/domain/DetailedAnalysis.java
+++ b/src/main/java/QRAB/QRAB/analysis/domain/DetailedAnalysis.java
@@ -1,0 +1,38 @@
+package QRAB.QRAB.analysis.domain;
+
+import QRAB.QRAB.BaseTimeEntity;
+import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.category.domain.Category;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "detailed_analysis")
+public class DetailedAnalysis extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long detailedAnalysisId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(columnDefinition = "JSON")
+    private String userAnalysis;
+
+    @Column(columnDefinition = "TEXT")
+    private String studyTips;
+
+    @Column(name = "study_references", columnDefinition = "JSON")
+    private String studyReferences;
+
+    private boolean isLatest = true;
+}

--- a/src/main/java/QRAB/QRAB/analysis/dto/DetailedAnalysisResponseDTO.java
+++ b/src/main/java/QRAB/QRAB/analysis/dto/DetailedAnalysisResponseDTO.java
@@ -1,0 +1,31 @@
+package QRAB.QRAB.analysis.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.util.List;
+
+@Getter
+@Setter
+public class DetailedAnalysisResponseDTO {
+    private String userAnalysis;
+    private StrongCategoriesDTO strongCategories;
+    private List<WeakCategoryDTO> weakCategories;
+
+    @Getter @Setter
+    public static class StrongCategoriesDTO {
+        private List<String> finalCategoryName;
+    }
+
+    @Getter @Setter
+    public static class WeakCategoryDTO {
+        private String finalCategoryName;
+        private List<String> studyTips;
+        private List<ReferenceDTO> references;
+    }
+
+    @Getter @Setter
+    public static class ReferenceDTO {
+        private String title;
+        private String link;
+    }
+}

--- a/src/main/java/QRAB/QRAB/analysis/repository/CategoryAnalysisRepository.java
+++ b/src/main/java/QRAB/QRAB/analysis/repository/CategoryAnalysisRepository.java
@@ -21,5 +21,7 @@ public interface CategoryAnalysisRepository extends JpaRepository<CategoryAnalys
     List<CategoryAnalysis> findByUserAndMonthGreaterThanEqual(@Param("user") User user, @Param("startMonth") String startMonth);
 
     @Query("SELECT ca FROM CategoryAnalysis ca WHERE ca.user = :user")
-    List<CategoryAnalysis> findByUser(@Param("user") User user);
+    Optional<CategoryAnalysis> findByUser(@Param("user") User user);
+
+    List<CategoryAnalysis> findByUserOrderByCategoryAccuracyDesc(User user);
 }

--- a/src/main/java/QRAB/QRAB/analysis/repository/CategoryStrengthRepository.java
+++ b/src/main/java/QRAB/QRAB/analysis/repository/CategoryStrengthRepository.java
@@ -1,0 +1,14 @@
+package QRAB.QRAB.analysis.repository;
+
+import QRAB.QRAB.analysis.domain.CategoryStrength;
+import QRAB.QRAB.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryStrengthRepository extends JpaRepository<CategoryStrength, Long> {
+    List<CategoryStrength> findByUserAndStrengthType(User user, CategoryStrength.StrengthType strengthType);
+    List<CategoryStrength> findByUser(User user);
+}

--- a/src/main/java/QRAB/QRAB/analysis/repository/DetailedAnalysisRepository.java
+++ b/src/main/java/QRAB/QRAB/analysis/repository/DetailedAnalysisRepository.java
@@ -1,0 +1,16 @@
+package QRAB.QRAB.analysis.repository;
+
+import QRAB.QRAB.analysis.domain.DetailedAnalysis;
+import QRAB.QRAB.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DetailedAnalysisRepository extends JpaRepository<DetailedAnalysis, Long> {
+    Optional<DetailedAnalysis> findByUserAndIsLatestTrue(User user);
+    List<DetailedAnalysis> findByUserAndCreatedAtBeforeAndIsLatestFalse(User user, LocalDateTime date);
+}

--- a/src/main/java/QRAB/QRAB/analysis/service/DetailedAnalysisService.java
+++ b/src/main/java/QRAB/QRAB/analysis/service/DetailedAnalysisService.java
@@ -1,0 +1,393 @@
+package QRAB.QRAB.analysis.service;
+
+import QRAB.QRAB.analysis.domain.CategoryAnalysis;
+import QRAB.QRAB.analysis.domain.CategoryStrength;
+import QRAB.QRAB.analysis.domain.DetailedAnalysis;
+import QRAB.QRAB.analysis.dto.DetailedAnalysisResponseDTO;
+import QRAB.QRAB.analysis.repository.CategoryAnalysisRepository;
+import QRAB.QRAB.analysis.repository.CategoryStrengthRepository;
+import QRAB.QRAB.analysis.repository.DetailedAnalysisRepository;
+import QRAB.QRAB.category.domain.Category;
+import QRAB.QRAB.category.repository.CategoryRepository;
+import QRAB.QRAB.chatgpt.service.ChatgptService;
+import QRAB.QRAB.quiz.domain.QuizAnswer;
+import QRAB.QRAB.quiz.repository.QuizAnswerRepository;
+import QRAB.QRAB.quiz.repository.QuizRepository;
+import QRAB.QRAB.quiz.repository.QuizResultRepository;
+import QRAB.QRAB.record.repository.RecordRepository;
+import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.user.repository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class DetailedAnalysisService {
+    private final ChatgptService chatgptService;
+    private final CategoryAnalysisRepository categoryAnalysisRepository;
+    private final DetailedAnalysisRepository detailedAnalysisRepository;
+    private final QuizAnswerRepository quizAnswerRepository;
+    private final UserRepository userRepository;
+    private final CategoryStrengthRepository categoryStrengthRepository;
+    private final RecordRepository recordRepository;
+
+    @Autowired
+    public DetailedAnalysisService(ChatgptService chatgptService,
+                                   CategoryAnalysisRepository categoryAnalysisRepository,
+                                   DetailedAnalysisRepository detailedAnalysisRepository,
+                                   QuizAnswerRepository quizAnswerRepository,
+                                   UserRepository userRepository,
+                                   CategoryStrengthRepository categoryStrengthRepository,
+                                   RecordRepository recordRepository) {
+        this.chatgptService = chatgptService;
+        this.categoryAnalysisRepository = categoryAnalysisRepository;
+        this.detailedAnalysisRepository = detailedAnalysisRepository;
+        this.quizAnswerRepository = quizAnswerRepository;
+        this.userRepository = userRepository;
+        this.categoryStrengthRepository = categoryStrengthRepository;
+        this.recordRepository = recordRepository;
+    }
+
+    /**
+     * 상세 분석 생성
+     * 1. 기존 상세 분석의 isLatest를 false로 설정
+     * 2. 카테고리별 강점/약점 업데이트
+     * 3. 퀴즈 요약 수집
+     * 4. GPT를 통한 분석 텍스트 생성
+     * 5. 약점 카테고리에 대한 학습 추천 생성
+     * 6. 상세 분석 저장
+     * 7. 응답 DTO 생성 및 반환
+     *
+     * @param username 분석할 사용자의 아이디
+     * @return DetailedAnalysisResponseDTO 상세 분석 결과
+     */
+    public DetailedAnalysisResponseDTO getDetailedAnalysis(String username) {
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // 1. 기존 상세 분석이 있다면 isLatest를 false로 설정
+        detailedAnalysisRepository.findByUserAndIsLatestTrue(user)
+                .ifPresent(analysis -> {
+                    analysis.setLatest(false);
+                    detailedAnalysisRepository.save(analysis);
+                });
+
+        // 2. 카테고리 강약점 업데이트
+        updateCategoryStrengths(user);
+
+        // 3. 퀴즈 요약 수집
+        List<String> strongCategorySummaries = getQuizSummaries(user, true);
+        List<String> weakCategorySummaries = getQuizSummaries(user, false);
+
+        // 4. GPT를 통한 분석 생성
+        String userAnalysis = chatgptService.generateDetailedAnalysis(
+                user.getNickname(),
+                strongCategorySummaries,
+                weakCategorySummaries,
+                getStrongCategories(user).stream()
+                        .map(this::getFinalCategoryName)
+                        .collect(Collectors.toList()),
+                getWeakCategories(user).stream()
+                        .map(this::getFinalCategoryName)
+                        .collect(Collectors.toList())
+        );
+
+        // 5. 약점 카테고리에 대한 학습 추천 생성
+        List<DetailedAnalysisResponseDTO.WeakCategoryDTO> weakCategoryDTOs = generateWeakCategoryRecommendations(
+                user,
+                getWeakCategories(user)
+        );
+
+        // 6. 상세 분석 저장
+        DetailedAnalysis detailedAnalysis = new DetailedAnalysis();
+        detailedAnalysis.setUser(user);
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+
+            // userAnalysis를 JSON 형식으로 변환
+            JsonNode userAnalysisJson = mapper.createObjectNode()
+                    .put("analysis", userAnalysis);
+            detailedAnalysis.setUserAnalysis(mapper.writeValueAsString(userAnalysisJson));
+
+            // studyTips를 JSON 형식으로 변환
+            Map<String, List<String>> studyTipsMap = weakCategoryDTOs.stream()
+                    .collect(Collectors.toMap(
+                            DetailedAnalysisResponseDTO.WeakCategoryDTO::getFinalCategoryName,
+                            DetailedAnalysisResponseDTO.WeakCategoryDTO::getStudyTips
+                    ));
+            detailedAnalysis.setStudyTips(mapper.writeValueAsString(studyTipsMap));
+
+            // studyReferences를 JSON 형식으로 변환
+            Map<String, List<DetailedAnalysisResponseDTO.ReferenceDTO>> referencesMap = weakCategoryDTOs.stream()
+                    .collect(Collectors.toMap(
+                            DetailedAnalysisResponseDTO.WeakCategoryDTO::getFinalCategoryName,
+                            DetailedAnalysisResponseDTO.WeakCategoryDTO::getReferences
+                    ));
+            detailedAnalysis.setStudyReferences(mapper.writeValueAsString(referencesMap));
+
+            detailedAnalysis.setLatest(true);
+            detailedAnalysisRepository.save(detailedAnalysis);
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to convert to JSON", e);
+        }
+
+        // 7. 응답 DTO 생성
+        return createResponseDTO(userAnalysis,
+                getStrongCategories(user),
+                weakCategoryDTOs);
+    }
+
+    // 약점 카테고리에 대한 학습 추천 생성
+    private List<DetailedAnalysisResponseDTO.WeakCategoryDTO> generateWeakCategoryRecommendations(User user, List<Category> weakCategories) {
+        return weakCategories.stream()
+                .map(category -> {
+                    DetailedAnalysisResponseDTO.WeakCategoryDTO dto = new DetailedAnalysisResponseDTO.WeakCategoryDTO();
+                    dto.setFinalCategoryName(getFinalCategoryName(category));
+
+                    // 학습 팁 생성
+                    List<String> weakSummaries = quizAnswerRepository.findByUserAndNoteCategory(user, category)
+                            .stream()
+                            .filter(answer -> !answer.isCorrect())
+                            .map(answer -> answer.getQuiz().getQuizSummary())
+                            .collect(Collectors.toList());
+
+                    dto.setStudyTips(chatgptService.generateStudyTips(category.getName(), weakSummaries));
+
+                    // 추천 자료 생성
+                    dto.setReferences(chatgptService.generateReferences(
+                            category.getName(),
+                            weakSummaries.stream()
+                                    .limit(3)
+                                    .collect(Collectors.joining(" "))
+                    ));
+
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 사용자의 카테고리별 강점/약점 업데이트
+     * 카테고리 정확도를 기준으로 상위 2개는 강점, 하위 2개는 약점으로 설정
+     *
+     * @param user 업데이트할 사용자
+     */
+    private void updateCategoryStrengths(User user) {
+        // 기존 카테고리 강약점 데이터 삭제
+        List<CategoryStrength> existingStrengths =
+                categoryStrengthRepository.findByUser(user);
+        categoryStrengthRepository.deleteAll(existingStrengths);
+
+        // CategoryAnalysis 데이터를 기반으로 새로운 강약점 분석
+        List<CategoryAnalysis> analyses =
+                categoryAnalysisRepository.findByUserOrderByCategoryAccuracyDesc(user);
+
+        // 상위 2개는 강점 카테고리로
+        analyses.stream()
+                .limit(2)
+                .forEach(analysis -> {
+                    CategoryStrength strength = new CategoryStrength();
+                    strength.setUser(user);
+                    strength.setCategory(analysis.getCategory());
+                    strength.setStrengthType(CategoryStrength.StrengthType.STRONG);
+                    categoryStrengthRepository.save(strength);
+                });
+
+        // 하위 2개는 약점 카테고리로
+        analyses.stream()
+                .sorted((a1, a2) ->
+                        Double.compare(a1.getCategoryAccuracy(), a2.getCategoryAccuracy()))
+                .limit(2)
+                .forEach(analysis -> {
+                    CategoryStrength strength = new CategoryStrength();
+                    strength.setUser(user);
+                    strength.setCategory(analysis.getCategory());
+                    strength.setStrengthType(CategoryStrength.StrengthType.WEAK);
+                    categoryStrengthRepository.save(strength);
+                });
+    }
+
+    /**
+     * 사용자의 강점 카테고리 목록 조회
+     *
+     * @param user 조회할 사용자
+     * @return 강점 카테고리 목록
+     */
+    private List<Category> getStrongCategories(User user) {
+        return categoryStrengthRepository
+                .findByUserAndStrengthType(user, CategoryStrength.StrengthType.STRONG)
+                .stream()
+                .map(CategoryStrength::getCategory)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 사용자의 약점 카테고리 목록 조회
+     *
+     * @param user 조회할 사용자
+     * @return 약점 카테고리 목록
+     */
+    private List<Category> getWeakCategories(User user) {
+        return categoryStrengthRepository
+                .findByUserAndStrengthType(user, CategoryStrength.StrengthType.WEAK)
+                .stream()
+                .map(CategoryStrength::getCategory)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 카테고리별 퀴즈 요약 조회
+     *
+     * @param user 조회할 사용자
+     * @param isStrong true면 강점 카테고리, false면 약점 카테고리의 요약을 조회
+     * @return 퀴즈 요약 목록
+     */
+    private List<String> getQuizSummaries(User user, boolean isStrong) {
+        List<Category> categories = isStrong ? getStrongCategories(user) : getWeakCategories(user);
+
+        return categories.stream()
+                .flatMap(category -> {
+                    List<QuizAnswer> answers = quizAnswerRepository.findByUserAndNoteCategory(user, category);
+                    if (isStrong) {
+                        // 강점 카테고리면 맞은 문제만 수집
+                        return answers.stream()
+                                .filter(QuizAnswer::isCorrect)
+                                .map(answer -> answer.getQuiz().getQuizSummary());
+                    } else {
+                        // 약점 카테고리면 틀린 문제만 수집
+                        return answers.stream()
+                                .filter(answer -> !answer.isCorrect())
+                                .map(answer -> answer.getQuiz().getQuizSummary());
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 카테고리의 최상위 카테고리명 반환
+     *
+     * @param category 대상 카테고리
+     * @return 부모 카테고리가 있으면 부모 카테고리명, 없으면 현재 카테고리명
+     */
+    private String getFinalCategoryName(Category category) {
+        return category.getParentCategory() != null ?
+                category.getParentCategory().getName() :
+                category.getName();
+    }
+
+    // 상세 분석 응답 DTO 생성
+    private DetailedAnalysisResponseDTO createResponseDTO(
+            String userAnalysis,
+            List<Category> strongCategories,
+            List<DetailedAnalysisResponseDTO.WeakCategoryDTO> weakCategoryDTOs) {
+        DetailedAnalysisResponseDTO responseDTO = new DetailedAnalysisResponseDTO();
+        responseDTO.setUserAnalysis(userAnalysis);
+
+        DetailedAnalysisResponseDTO.StrongCategoriesDTO strongCategoriesDTO =
+                new DetailedAnalysisResponseDTO.StrongCategoriesDTO();
+        strongCategoriesDTO.setFinalCategoryName(
+                strongCategories.stream()
+                        .map(this::getFinalCategoryName)
+                        .collect(Collectors.toList())
+        );
+        responseDTO.setStrongCategories(strongCategoriesDTO);
+        responseDTO.setWeakCategories(weakCategoryDTOs);
+
+        return responseDTO;
+    }
+
+    /**
+    *상세 분석 조회
+     */
+    public DetailedAnalysisResponseDTO getLatestDetailedAnalysis(String username) {
+        User user = userRepository.findOneWithAuthoritiesByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        DetailedAnalysis latestAnalysis = detailedAnalysisRepository.findByUserAndIsLatestTrue(user)
+                .orElseThrow(() -> new RuntimeException("No analysis found"));
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+
+            // userAnalysis JSON 파싱
+            JsonNode userAnalysisNode = mapper.readTree(latestAnalysis.getUserAnalysis());
+            String userAnalysis = userAnalysisNode.get("analysis").asText();
+
+            // studyTips JSON 파싱
+            Map<String, List<String>> studyTipsMap = mapper.readValue(
+                    latestAnalysis.getStudyTips(),
+                    new TypeReference<Map<String, List<String>>>() {}
+            );
+
+            // studyReferences JSON 파싱
+            Map<String, List<DetailedAnalysisResponseDTO.ReferenceDTO>> referencesMap = mapper.readValue(
+                    latestAnalysis.getStudyReferences(),
+                    new TypeReference<Map<String, List<DetailedAnalysisResponseDTO.ReferenceDTO>>>() {}
+            );
+
+            // WeakCategoryDTO 리스트 생성
+            List<DetailedAnalysisResponseDTO.WeakCategoryDTO> weakCategoryDTOs = getWeakCategories(user).stream()
+                    .map(category -> {
+                        String categoryName = getFinalCategoryName(category);
+                        DetailedAnalysisResponseDTO.WeakCategoryDTO dto = new DetailedAnalysisResponseDTO.WeakCategoryDTO();
+                        dto.setFinalCategoryName(categoryName);
+                        dto.setStudyTips(studyTipsMap.get(categoryName));
+                        dto.setReferences(referencesMap.get(categoryName));
+                        return dto;
+                    })
+                    .collect(Collectors.toList());
+
+            return createResponseDTO(
+                    userAnalysis,
+                    getStrongCategories(user),
+                    weakCategoryDTOs
+            );
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse JSON data", e);
+        }
+    }
+
+    /**
+     * 3개월 이상 된 상세 분석 기록을 삭제
+     * 매일 자정에 실행되며, 당일 로그인한 사용자의 기록만 처리
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void cleanUpOldRecords() {
+        // 오늘 날짜 가져오기
+        LocalDate today = LocalDate.now();
+
+        // 당일 로그인한 사용자들의 Record 조회
+        List<QRAB.QRAB.record.domain.Record> todayRecords = recordRepository.findByLoginDate(today);
+
+        // Record에서 User 목록 추출 (중복 제거)
+        List<User> todayActiveUsers = todayRecords.stream()
+                .map(QRAB.QRAB.record.domain.Record::getUser)
+                .distinct()
+                .collect(Collectors.toList());
+
+        // 3개월 이전 날짜 계산
+        LocalDateTime threshold = LocalDateTime.now().minusMonths(3);
+
+        // 오늘 로그인한 사용자들의 3개월 이상된 분석 기록만 삭제
+        todayActiveUsers.forEach(user -> {
+            List<DetailedAnalysis> oldRecords = detailedAnalysisRepository
+                    .findByUserAndCreatedAtBeforeAndIsLatestFalse(user, threshold);
+            detailedAnalysisRepository.deleteAll(oldRecords);
+        });
+    }
+}

--- a/src/main/java/QRAB/QRAB/quiz/repository/QuizAnswerRepository.java
+++ b/src/main/java/QRAB/QRAB/quiz/repository/QuizAnswerRepository.java
@@ -4,6 +4,7 @@ import QRAB.QRAB.note.domain.Note;
 import QRAB.QRAB.quiz.domain.QuizAnswer;
 import QRAB.QRAB.quiz.domain.QuizResult;
 import QRAB.QRAB.user.domain.User;
+import QRAB.QRAB.category.domain.Category;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -30,11 +31,12 @@ public interface QuizAnswerRepository extends JpaRepository<QuizAnswer, Long> {
     @Query("SELECT qa FROM QuizAnswer qa WHERE qa.quiz.quizId = :quizId AND qa.isCorrect = false")
     Optional<QuizAnswer> findByQuizIdAndIsCorrectFalse(@Param("quizId") Long quizId);
 
-
     // 최근 틀린 퀴즈 조회
     @Query("SELECT qa FROM QuizAnswer qa WHERE qa.isCorrect = false ORDER BY qa.quizSet.createdAt DESC")
     List<QuizAnswer> findRecentWrongAnswers();
 
+    @Query("SELECT qa FROM QuizAnswer qa WHERE qa.quizResult.user = :user AND qa.quiz.quizSet.note.category = :category")
+    List<QuizAnswer> findByUserAndNoteCategory(@Param("user") User user, @Param("category") Category category);
 
 }
 

--- a/src/main/java/QRAB/QRAB/record/repository/RecordRepository.java
+++ b/src/main/java/QRAB/QRAB/record/repository/RecordRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long> {
     boolean existsByUserAndLoginDate(User user, LocalDate loginDate);
+    List<Record> findByLoginDate(LocalDate loginDate);
 }


### PR DESCRIPTION
- 당일 로그인한 사용자의 것만 자정에 자동으로 분석하도록 구현하고, 조회만 가능케 하려 했으나 편의를 위해 수동 생성, 자동 생성과 조회 별도로 구현
- /analysis/detailed-analysis에서 post 매핑으로 상세 분석 수동 생성
- /analysis/detailed-analysis/lates에서 get 매핑으로 가장 최근 상세 분석 조회
- 스케줄러를 이용해 당일 로그인한 사용자에 한해 자정에 상세 분석을 생성하고, 3개월이 지난 데이터는 자동 삭제되도록 구현