### PR TITLE
fix: 일별 정답률 계산 로직 수정

### DIFF
--- a/src/main/java/QRAB/QRAB/analysis/service/DailyAnalysisService.java
+++ b/src/main/java/QRAB/QRAB/analysis/service/DailyAnalysisService.java
@@ -33,11 +33,13 @@ public class DailyAnalysisService {
         DailyAnalysis dailyAnalysis = dailyAnalysisRepository.findByUserAndDate(user, date)
                 .orElseGet(() -> new DailyAnalysis(user, date, 0, 0.0f));
 
-        dailyAnalysis.setSolvedQuizCount(dailyAnalysis.getSolvedQuizCount() + solvedQuizCount);
+        // 기존 데이터와 새로운 데이터를 합산해 평균 계산
+        int newTotalCount = dailyAnalysis.getSolvedQuizCount() + solvedQuizCount;
+        float weightedAccuracy = (dailyAnalysis.getAverageAccuracy() * dailyAnalysis.getSolvedQuizCount()
+                + accuracy * solvedQuizCount) / newTotalCount;
 
-        float totalAccuracy = (dailyAnalysis.getAverageAccuracy() * dailyAnalysis.getSolvedQuizCount())
-                + (accuracy * solvedQuizCount);
-        dailyAnalysis.setAverageAccuracy(totalAccuracy / (dailyAnalysis.getSolvedQuizCount() + solvedQuizCount));
+        dailyAnalysis.setSolvedQuizCount(newTotalCount);
+        dailyAnalysis.setAverageAccuracy(weightedAccuracy);
 
         dailyAnalysisRepository.save(dailyAnalysis);
     }


### PR DESCRIPTION
- 기존 퀴즈 단위 업데이트에서 퀴즈 세트 단위로 분석 업데이트하도록 변경
- 정답률을 기존 데이터에 합산해 평균을 계산하는 로직에서 중복 계산되던 문제 해결